### PR TITLE
Update regex to correctly identify Windows 10

### DIFF
--- a/src/Spectre.Console/Internal/Colors/ColorSystemDetector.cs
+++ b/src/Spectre.Console/Internal/Colors/ColorSystemDetector.cs
@@ -19,7 +19,7 @@ namespace Spectre.Console.Internal
             {
                 if (supportsAnsi)
                 {
-                    var regex = new Regex("^Microsoft Windows (?'major'[0-9]*).(?'minor'[0-9]*).(?'build'[0-9]*)$");
+                    var regex = new Regex("^Microsoft Windows (?'major'[0-9]*).(?'minor'[0-9]*).(?'build'[0-9]*)\\s*$");
                     var match = regex.Match(RuntimeInformation.OSDescription);
                     if (match.Success && int.TryParse(match.Groups["major"].Value, out var major))
                     {


### PR DESCRIPTION
When running .NET Core 2.1 or .NET Framework 4.6.1, the used regex for
detecting Windows 10 TrueColor support does not match the OSDescription.
The reason for this is because on those frameworks the description has
trailing whitespaces, but they do not on .NET Core 3.1.
This pull request updates the regex to ignore any trailing whitespaces.
