### PR TITLE
Fix Unescaped Bracket

### DIFF
--- a/examples/Grid/Program.cs
+++ b/examples/Grid/Program.cs
@@ -7,7 +7,7 @@ namespace GridExample
         static void Main(string[] args)
         {
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("Usage: [grey]dotnet [blue]run[/] [[options] [[[[--] <additional arguments>...]][/]");
+            AnsiConsole.MarkupLine("Usage: [grey]dotnet [blue]run[/] [[options]] [[[[--]] <additional arguments>...]]]][/]");
             AnsiConsole.WriteLine();
 
             var grid = new Grid();


### PR DESCRIPTION
Was throwing an error because of the unescaped end bracket
at the end of options.

```
"Usage: [grey]dotnet [blue]run[/] [[options]] [[[[--]] <additional arguments>...]]]][/]"
```