### PR TITLE
Merge segments before rendering

### DIFF
--- a/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
+++ b/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
@@ -12,7 +12,7 @@ namespace Spectre.Console.Tests.Unit
         {
             [Theory]
             [InlineData("[yellow]Hello[/]", "[93mHello[0m")]
-            [InlineData("[yellow]Hello [italic]World[/]![/]", "[93mHello[0m[93m [0m[3;93mWorld[0m[93m![0m")]
+            [InlineData("[yellow]Hello [italic]World[/]![/]", "[93mHello [0m[3;93mWorld[0m[93m![0m")]
             public void Should_Output_Expected_Ansi_For_Markup(string markup, string expected)
             {
                 // Given
@@ -26,7 +26,7 @@ namespace Spectre.Console.Tests.Unit
             }
 
             [Theory]
-            [InlineData("[yellow]Hello [[ World[/]", "[93mHello[0m[93m [0m[93m[[0m[93m [0m[93mWorld[0m")]
+            [InlineData("[yellow]Hello [[ World[/]", "[93mHello [ World[0m")]
             public void Should_Be_Able_To_Escape_Tags(string markup, string expected)
             {
                 // Given

--- a/src/Spectre.Console/ConsoleExtensions.Rendering.cs
+++ b/src/Spectre.Console/ConsoleExtensions.Rendering.cs
@@ -30,8 +30,11 @@ namespace Spectre.Console
 
             using (console.PushStyle(Style.Plain))
             {
+                var segments = renderable.Render(options, console.Width);
+                segments = Segment.Merge(segments);
+
                 var current = Style.Plain;
-                foreach (var segment in renderable.Render(options, console.Width))
+                foreach (var segment in segments)
                 {
                     if (string.IsNullOrEmpty(segment.Text))
                     {

--- a/src/Spectre.Console/Internal/Utilities/ConsoleHelper.cs
+++ b/src/Spectre.Console/Internal/Utilities/ConsoleHelper.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Spectre.Console.Internal
 {

--- a/src/Spectre.Console/Rendering/Segment.cs
+++ b/src/Spectre.Console/Rendering/Segment.cs
@@ -16,7 +16,7 @@ namespace Spectre.Console.Rendering
         /// <summary>
         /// Gets the segment text.
         /// </summary>
-        public string Text { get; }
+        public string Text { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether or not this is an expicit line break
@@ -224,6 +224,41 @@ namespace Spectre.Console.Rendering
             }
 
             return lines;
+        }
+
+        internal static IEnumerable<Segment> Merge(IEnumerable<Segment> segments)
+        {
+            var result = new List<Segment>();
+
+            var previous = (Segment?)null;
+            foreach (var segment in segments)
+            {
+                if (previous == null)
+                {
+                    previous = segment;
+                    continue;
+                }
+
+                // Same style?
+                if (previous.Style.Equals(segment.Style))
+                {
+                    // Modify the content of the previous segment
+                    previous.Text += segment.Text;
+                }
+                else
+                {
+                    // Push the current one to the results.
+                    result.Add(previous);
+                    previous = segment;
+                }
+            }
+
+            if (previous != null)
+            {
+                result.Add(previous);
+            }
+
+            return result;
         }
 
         internal static List<List<SegmentLine>> MakeSameHeight(int cellHeight, List<List<SegmentLine>> cells)


### PR DESCRIPTION
This will reduce the number of segments to render and produce cleaner ANSI escape code sequences.

Closes #46