### PR TITLE
Don't throw when console is small

### DIFF
--- a/src/Spectre.Console/Rendering/Segment.cs
+++ b/src/Spectre.Console/Rendering/Segment.cs
@@ -306,7 +306,7 @@ namespace Spectre.Console.Rendering
                     {
                         // This shouldn't really occur, but I don't like
                         // never ending loops if it does...
-                        throw new InvalidOperationException("Text folding failed since 'take' was zero.");
+                        return new List<Segment>();
                     }
 
                     result.Add(new Segment(segment.Text.Substring(index, take), segment.Style));


### PR DESCRIPTION
this just returns an empty collection when
take is 0. It leads to some strange output, but
it doesn't blow up.

 #93

![image](https://user-images.githubusercontent.com/228256/95508657-58ca0d80-0981-11eb-9698-210ebf5dd3b8.png)

