### PR TITLE
Fix incorrect link on Docs

### DIFF
--- a/docs/input/markup.md
+++ b/docs/input/markup.md
@@ -67,7 +67,7 @@ To output an emoji as part of markup, you can use emoji shortcodes.
 AnsiConsole.MarkupLine("Hello :globe_showing_europe_africa:!");
 ```
 
-For a list of emoji, see the [Emojis](xref:styles) appendix section.
+For a list of emoji, see the [Emojis](xref:emojis) appendix section.
 
 # Colors
 


### PR DESCRIPTION
before
```
For a list of emoji, see the [Emojis](xref:styles) appendix section.
```
after
```
For a list of emoji, see the [Emojis](xref:emojis) appendix section.
```