### PR TITLE
Do not draw tables that can't be drawn

### DIFF
--- a/examples/Tables/Program.cs
+++ b/examples/Tables/Program.cs
@@ -19,7 +19,7 @@ namespace TableExample
 
         private static void RenderSimpleTable()
         {
-            // Create the table.
+            // Create the table
             var table = new Table();
             table.AddColumn(new TableColumn("[u]Foo[/]"));
             table.AddColumn(new TableColumn("[u]Bar[/]"));
@@ -35,7 +35,7 @@ namespace TableExample
 
         private static void RenderBigTable()
         {
-            // Create the table.
+            // Create the table
             var table = new Table().SetBorder(TableBorder.Rounded);
             table.AddColumn("[red underline]Foo[/]");
             table.AddColumn(new TableColumn("[blue]Bar[/]") { Alignment = Justify.Right, NoWrap = true });
@@ -57,16 +57,16 @@ namespace TableExample
 
         private static void RenderNestedTable()
         {
-            // Create simple table.
+            // Create simple table
             var simple = new Table().SetBorder(TableBorder.Rounded).SetBorderColor(Color.Red);
-            simple.AddColumn(new TableColumn("[u]Foo[/]").Centered());
-            simple.AddColumn(new TableColumn("[u]Bar[/]"));
-            simple.AddColumn(new TableColumn("[u]Baz[/]"));
+            simple.AddColumn(new TableColumn("[u]CDE[/]").Centered());
+            simple.AddColumn(new TableColumn("[u]FED[/]"));
+            simple.AddColumn(new TableColumn("[u]IHG[/]"));
             simple.AddRow("Hello", "[red]World![/]", "");
             simple.AddRow("[blue]Bonjour[/]", "[white]le[/]", "[red]monde![/]");
             simple.AddRow("[blue]Hej[/]", "[yellow]Världen![/]", "");
 
-            // Create other table.
+            // Create other table
             var second = new Table().SetBorder(TableBorder.Square).SetBorderColor(Color.Green);
             second.AddColumn(new TableColumn("[u]Foo[/]"));
             second.AddColumn(new TableColumn("[u]Bar[/]"));
@@ -75,12 +75,11 @@ namespace TableExample
             second.AddRow(simple, new Text("Whaaat"), new Text("Lolz"));
             second.AddRow("[blue]Hej[/]", "[yellow]Världen![/]", "");
 
+            // Create the outer most table
             var table = new Table().SetBorder(TableBorder.Rounded);
-            table.AddColumn(new TableColumn(new Panel("[u]Foo[/]").SetBorderColor(Color.Red)));
-            table.AddColumn(new TableColumn(new Panel("[u]Bar[/]").SetBorderColor(Color.Green)));
-            table.AddColumn(new TableColumn(new Panel("[u]Baz[/]").SetBorderColor(Color.Blue)));
-
-            // Add some rows
+            table.AddColumn(new TableColumn(new Panel("[u]ABC[/]").SetBorderColor(Color.Red)));
+            table.AddColumn(new TableColumn(new Panel("[u]DEF[/]").SetBorderColor(Color.Green)));
+            table.AddColumn(new TableColumn(new Panel("[u]GHI[/]").SetBorderColor(Color.Blue)));
             table.AddRow(new Text("Hello").Centered(), new Markup("[red]World![/]"), Text.Empty);
             table.AddRow(second, new Text("Whaaat"), new Text("Lol"));
             table.AddRow(new Markup("[blue]Hej[/]").Centered(), new Markup("[yellow]Världen![/]"), Text.Empty);

--- a/src/Spectre.Console.Tests/Unit/TableTests.cs
+++ b/src/Spectre.Console.Tests/Unit/TableTests.cs
@@ -383,5 +383,54 @@ namespace Spectre.Console.Tests.Unit
             console.Lines[1].ShouldBe("│ Foo │ Bar │   Baz  │");
             console.Lines[2].ShouldBe("└─────┴─────┴────────┘");
         }
+
+        [Fact]
+        public void Should_Not_Draw_Tables_That_Are_Impossible_To_Draw()
+        {
+            // Given
+            var console = new PlainConsole(width: 25);
+
+            var first = new Table().SetBorder(TableBorder.Rounded).SetBorderColor(Color.Red);
+            first.AddColumn(new TableColumn("[u]PS1[/]").Centered());
+            first.AddColumn(new TableColumn("[u]PS2[/]"));
+            first.AddColumn(new TableColumn("[u]PS3[/]"));
+            first.AddRow("Hello", "[red]World[/]", string.Empty);
+            first.AddRow("[blue]Bonjour[/]", "[white]le[/]", "[red]monde![/]");
+            first.AddRow("[blue]Hej[/]", "[yellow]Världen[/]", string.Empty);
+
+            var second = new Table().SetBorder(TableBorder.Square).SetBorderColor(Color.Green);
+            second.AddColumn(new TableColumn("[u]Foo[/]"));
+            second.AddColumn(new TableColumn("[u]Bar[/]"));
+            second.AddColumn(new TableColumn("[u]Baz[/]"));
+            second.AddRow("Hello", "[red]World[/]", string.Empty);
+            second.AddRow(first, new Text("Whaaat"), new Text("Lolz"));
+            second.AddRow("[blue]Hej[/]", "[yellow]Världen[/]", string.Empty);
+
+            var table = new Table().SetBorder(TableBorder.Rounded);
+            table.AddColumn(new TableColumn(new Panel("[u]ABC[/]").SetBorderColor(Color.Red)));
+            table.AddColumn(new TableColumn(new Panel("[u]DEF[/]").SetBorderColor(Color.Green)));
+            table.AddColumn(new TableColumn(new Panel("[u]GHI[/]").SetBorderColor(Color.Blue)));
+            table.AddRow(new Text("Hello").Centered(), new Markup("[red]World[/]"), Text.Empty);
+            table.AddRow(second, new Text("Whaat"), new Text("Lol").RightAligned());
+            table.AddRow(new Markup("[blue]Hej[/]"), new Markup("[yellow]Världen[/]"), Text.Empty);
+
+            // When
+            console.Render(table);
+
+            // Then
+            console.Lines.Count.ShouldBe(12);
+            console.Lines[00].ShouldBe("╭───────┬───────┬───────╮");
+            console.Lines[01].ShouldBe("│ ┌───┐ │ ┌───┐ │ ┌───┐ │");
+            console.Lines[02].ShouldBe("│ │ A │ │ │ D │ │ │ G │ │");
+            console.Lines[03].ShouldBe("│ │ B │ │ │ E │ │ │ H │ │");
+            console.Lines[04].ShouldBe("│ │ C │ │ │ F │ │ │ I │ │");
+            console.Lines[05].ShouldBe("│ └───┘ │ └───┘ │ └───┘ │");
+            console.Lines[06].ShouldBe("├───────┼───────┼───────┤");
+            console.Lines[07].ShouldBe("│ Hello │ World │       │");
+            console.Lines[08].ShouldBe("│ …     │ Whaat │   Lol │");
+            console.Lines[09].ShouldBe("│ Hej   │ Värld │       │");
+            console.Lines[10].ShouldBe("│       │ en    │       │");
+            console.Lines[11].ShouldBe("╰───────┴───────┴───────╯");
+        }
     }
 }

--- a/src/Spectre.Console/Rendering/Segment.cs
+++ b/src/Spectre.Console/Rendering/Segment.cs
@@ -120,6 +120,54 @@ namespace Spectre.Console.Rendering
         }
 
         /// <summary>
+        /// Gets the number of cells that the segments occupies in the console.
+        /// </summary>
+        /// <param name="context">The render context.</param>
+        /// <param name="segments">The segments to measure.</param>
+        /// <returns>The number of cells that the segments occupies in the console.</returns>
+        public static int CellLength(RenderContext context, List<Segment> segments)
+        {
+            return segments.Sum(segment => segment.CellLength(context));
+        }
+
+        /// <summary>
+        /// Truncates the segments to the specified width.
+        /// </summary>
+        /// <param name="context">The render context.</param>
+        /// <param name="segments">The segments to truncate.</param>
+        /// <param name="maxWidth">The maximum width that the segments may occupy.</param>
+        /// <returns>A list of segments that has been truncated.</returns>
+        public static List<Segment> Truncate(RenderContext context, IEnumerable<Segment> segments, int maxWidth)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (segments is null)
+            {
+                throw new ArgumentNullException(nameof(segments));
+            }
+
+            var result = new List<Segment>();
+
+            var totalWidth = 0;
+            foreach (var segment in segments)
+            {
+                var segmentWidth = segment.CellLength(context);
+                if (totalWidth + segmentWidth > maxWidth)
+                {
+                    break;
+                }
+
+                result.Add(segment);
+                totalWidth += segmentWidth;
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Splits the provided segments into lines.
         /// </summary>
         /// <param name="segments">The segments to split.</param>
@@ -315,11 +363,25 @@ namespace Spectre.Console.Rendering
             }
             else if (overflow == Overflow.Crop)
             {
-                result.Add(new Segment(segment.Text.Substring(0, width), segment.Style));
+                if (Math.Max(0, width - 1) == 0)
+                {
+                    result.Add(new Segment(string.Empty, segment.Style));
+                }
+                else
+                {
+                    result.Add(new Segment(segment.Text.Substring(0, width), segment.Style));
+                }
             }
             else if (overflow == Overflow.Ellipsis)
             {
-                result.Add(new Segment(segment.Text.Substring(0, width - 1) + "…", segment.Style));
+                if (Math.Max(0, width - 1) == 0)
+                {
+                    result.Add(new Segment("…", segment.Style));
+                }
+                else
+                {
+                    result.Add(new Segment(segment.Text.Substring(0, width - 1) + "…", segment.Style));
+                }
             }
 
             return result;

--- a/src/Spectre.Console/Widgets/Paragraph.cs
+++ b/src/Spectre.Console/Widgets/Paragraph.cs
@@ -193,6 +193,12 @@ namespace Spectre.Console
 
         private List<SegmentLine> SplitLines(RenderContext context, int maxWidth)
         {
+            if (maxWidth <= 0)
+            {
+                // Nothing fits, so return an empty line.
+                return new List<SegmentLine>();
+            }
+
             if (_lines.Max(x => x.CellWidth(context)) <= maxWidth)
             {
                 return Clone();

--- a/src/Spectre.Console/Widgets/TableColumn.cs
+++ b/src/Spectre.Console/Widgets/TableColumn.cs
@@ -41,7 +41,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="text">The table column text.</param>
         public TableColumn(string text)
-            : this(new Markup(text))
+            : this(new Markup(text).SetOverflow(Overflow.Ellipsis))
         {
         }
 


### PR DESCRIPTION
This is a temporary fix for undrawable tables until we've implemented a proper strategy. What this does is that it replaces
an undrawable table with an ellipsis (...).

This should only occur in either super big tables or deeply nested tables in a console with a small buffer width.