### PR TITLE
Remove verbs from extension methods

### DIFF
--- a/examples/Borders/Program.cs
+++ b/examples/Borders/Program.cs
@@ -8,29 +8,23 @@ namespace BordersExample
     {
         public static void Main()
         {
-            Debugger.Launch();
-
             // Render panel borders
-            AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("[white bold underline]PANEL BORDERS[/]");
-            AnsiConsole.WriteLine();
-            RenderPanelBorders();
+            HorizontalRule("PANEL BORDERS");
+            PanelBorders();
 
             // Render table borders
-            AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine("[white bold underline]TABLE BORDERS[/]");
-            AnsiConsole.WriteLine();
-            RenderTableBorders();
+            HorizontalRule("TABLE BORDERS");
+            TableBorders();
         }
 
-        private static void RenderPanelBorders()
+        private static void PanelBorders()
         {
             static IRenderable CreatePanel(string name, BoxBorder border)
             {
                 return new Panel($"This is a panel with\nthe [yellow]{name}[/] border.")
-                    .SetHeader($" {name} ", Style.Parse("blue"), Justify.Center)
-                    .SetBorderStyle(Style.Parse("grey"))
-                    .SetBorder(border);
+                    .Header($" {name} ", Style.Parse("blue"), Justify.Center)
+                    .Border(border)
+                    .BorderStyle(Style.Parse("grey"));
             }
 
             var items = new[]
@@ -49,19 +43,18 @@ namespace BordersExample
                     new Padding(2,0,0,0)));
         }
 
-        private static void RenderTableBorders()
+        private static void TableBorders()
         {
             static IRenderable CreateTable(string name, TableBorder border)
             {
-                var table = new Table().SetBorder(border);
+                var table = new Table().Border(border);
                 table.AddColumn("[yellow]Header 1[/]");
                 table.AddColumn("[yellow]Header 2[/]", col => col.RightAligned());
                 table.AddRow("Cell", "Cell");
                 table.AddRow("Cell", "Cell");
 
                 return new Panel(table)
-                    .SetHeader($" {name} ", Style.Parse("blue"), Justify.Center)
-                    .SetBorderStyle(Style.Parse("grey"))
+                    .Header($" {name} ", Style.Parse("blue"), Justify.Center)
                     .NoBorder();
             }
 
@@ -87,6 +80,13 @@ namespace BordersExample
             };
 
             AnsiConsole.Render(new Columns(items).Collapse());
+        }
+
+        private static void HorizontalRule(string title)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.Render(new Rule($"[white bold]{title}[/]").RuleStyle("grey").LeftAligned());
+            AnsiConsole.WriteLine();
         }
     }
 }

--- a/examples/Calendars/Program.cs
+++ b/examples/Calendars/Program.cs
@@ -9,8 +9,8 @@ namespace Calendars
             AnsiConsole.WriteLine();
             AnsiConsole.Render(new Calendar(2020, 10)
                     .RoundedBorder()
-                    .SetHighlightStyle(Style.Parse("red"))
-                    .SetHeaderStyle(Style.Parse("yellow"))
+                    .HighlightStyle(Style.Parse("red"))
+                    .HeaderStyle(Style.Parse("yellow"))
                     .AddCalendarEvent("An event", 2020, 9, 22)
                     .AddCalendarEvent("Another event", 2020, 10, 2)
                     .AddCalendarEvent("A third event", 2020, 10, 13));

--- a/examples/Colors/Program.cs
+++ b/examples/Colors/Program.cs
@@ -24,7 +24,7 @@ namespace ColorExample
 
                 AnsiConsole.ResetColors();
                 AnsiConsole.WriteLine();
-                AnsiConsole.Render(new Rule("[yellow bold underline]3-bit Colors[/]").SetStyle("grey").LeftAligned());
+                AnsiConsole.Render(new Rule("[yellow bold underline]3-bit Colors[/]").RuleStyle("grey").LeftAligned());
                 AnsiConsole.WriteLine();
 
                 for (var i = 0; i < 8; i++)
@@ -47,7 +47,7 @@ namespace ColorExample
 
                 AnsiConsole.ResetColors();
                 AnsiConsole.WriteLine();
-                AnsiConsole.Render(new Rule("[yellow bold underline]4-bit Colors[/]").SetStyle("grey").LeftAligned());
+                AnsiConsole.Render(new Rule("[yellow bold underline]4-bit Colors[/]").RuleStyle("grey").LeftAligned());
                 AnsiConsole.WriteLine();
 
                 for (var i = 0; i < 16; i++)
@@ -70,7 +70,7 @@ namespace ColorExample
 
                 AnsiConsole.ResetColors();
                 AnsiConsole.WriteLine();
-                AnsiConsole.Render(new Rule("[yellow bold underline]8-bit Colors[/]").SetStyle("grey").LeftAligned());
+                AnsiConsole.Render(new Rule("[yellow bold underline]8-bit Colors[/]").RuleStyle("grey").LeftAligned());
                 AnsiConsole.WriteLine();
 
                 for (var i = 0; i < 16; i++)
@@ -97,7 +97,7 @@ namespace ColorExample
 
                 AnsiConsole.ResetColors();
                 AnsiConsole.WriteLine();
-                AnsiConsole.Render(new Rule("[yellow bold underline]24-bit Colors[/]").SetStyle("grey").LeftAligned());
+                AnsiConsole.Render(new Rule("[yellow bold underline]24-bit Colors[/]").RuleStyle("grey").LeftAligned());
                 AnsiConsole.WriteLine();
 
                 var index = 0;

--- a/examples/Columns/Program.cs
+++ b/examples/Columns/Program.cs
@@ -19,8 +19,8 @@ namespace ColumnsExample
             var cards = new List<Panel>();
             foreach(var user in users.results)
             {
-                cards.Add(new Panel(GetCard(user))
-                    .SetHeader($"{user.location.country}")
+                cards.Add(new Panel(GetCardContent(user))
+                    .Header($"{user.location.country}")
                     .RoundedBorder().Expand());
             }
 
@@ -28,7 +28,7 @@ namespace ColumnsExample
             AnsiConsole.Render(new Columns(cards));
         }
 
-        private static string GetCard(dynamic user)
+        private static string GetCardContent(dynamic user)
         {
             var name = $"{user.name.first} {user.name.last}";
             var country = $"{user.location.city}";

--- a/examples/Exceptions/Program.cs
+++ b/examples/Exceptions/Program.cs
@@ -32,15 +32,15 @@ namespace Exceptions
                     Format = ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks,
                     Style = new ExceptionStyle
                     {
-                        Exception = Style.WithForeground(Color.Grey),
-                        Message = Style.WithForeground(Color.White),
-                        NonEmphasized = Style.WithForeground(Color.Cornsilk1),
-                        Parenthesis = Style.WithForeground(Color.Cornsilk1),
-                        Method = Style.WithForeground(Color.Red),
-                        ParameterName = Style.WithForeground(Color.Cornsilk1),
-                        ParameterType = Style.WithForeground(Color.Red),
-                        Path = Style.WithForeground(Color.Red),
-                        LineNumber = Style.WithForeground(Color.Cornsilk1),
+                        Exception = new Style().Foreground(Color.Grey),
+                        Message = new Style().Foreground(Color.White),
+                        NonEmphasized = new Style().Foreground(Color.Cornsilk1),
+                        Parenthesis = new Style().Foreground(Color.Cornsilk1),
+                        Method = new Style().Foreground(Color.Red),
+                        ParameterName = new Style().Foreground(Color.Cornsilk1),
+                        ParameterType = new Style().Foreground(Color.Red),
+                        Path = new Style().Foreground(Color.Red),
+                        LineNumber = new Style().Foreground(Color.Cornsilk1),
                     }
                 });
             }

--- a/examples/Grids/Program.cs
+++ b/examples/Grids/Program.cs
@@ -11,7 +11,7 @@ namespace GridExample
             AnsiConsole.WriteLine();
 
             var grid = new Grid();
-            grid.AddColumn(new GridColumn { NoWrap = true });
+            grid.AddColumn(new GridColumn().NoWrap());
             grid.AddColumn(new GridColumn().PadLeft(2));
             grid.AddRow("Options:");
             grid.AddRow("  [blue]-h[/], [blue]--help[/]", "Show command line help.");

--- a/examples/Info/Program.cs
+++ b/examples/Info/Program.cs
@@ -17,7 +17,7 @@ namespace InfoExample
 
             AnsiConsole.Render(
                 new Panel(grid)
-                    .SetHeader("Information"));
+                    .Header("Information"));
         }
 
         private static string YesNo(bool value)

--- a/examples/Panels/Program.cs
+++ b/examples/Panels/Program.cs
@@ -13,28 +13,33 @@ namespace PanelExample
             AnsiConsole.Render(
                 new Panel(
                     new Panel(content)
-                        .SetBorder(BoxBorder.Rounded)));
+                        .Border(BoxBorder.Rounded)));
 
             // Left adjusted panel with text
             AnsiConsole.Render(
                 new Panel(new Text("Left adjusted\nLeft").LeftAligned())
                     .Expand()
                     .SquareBorder()
-                    .SetHeader("Left", Style.WithForeground(Color.Red)));
+                    .Header("Left")
+                    .HeaderStyle("red"));
 
             // Centered ASCII panel with text
             AnsiConsole.Render(
                 new Panel(new Text("Centered\nCenter").Centered())
                     .Expand()
                     .AsciiBorder()
-                    .SetHeader("Center", Style.WithForeground(Color.Green), Justify.Center));
+                    .Header("Center")
+                    .HeaderStyle("green")
+                    .HeaderAlignment(Justify.Center));
 
             // Right adjusted, rounded panel with text
             AnsiConsole.Render(
                 new Panel(new Text("Right adjusted\nRight").RightAligned())
                     .Expand()
                     .RoundedBorder()
-                    .SetHeader("Right", Style.WithForeground(Color.Blue), Justify.Right));
+                    .Header("Right")
+                    .HeaderStyle("blue")
+                    .HeaderAlignment(Justify.Right));
         }
     }
 }

--- a/examples/Rules/Program.cs
+++ b/examples/Rules/Program.cs
@@ -7,21 +7,33 @@ namespace EmojiExample
         public static void Main(string[] args)
         {
             // No title
-            Render(new Rule().SetStyle("yellow"));
+            WrapInPanel(
+                new Rule()
+                    .RuleStyle(Style.Parse("yellow"))
+                    .LeftAligned());
 
             // Left aligned title
-            Render(new Rule("[white]Left aligned[/]").LeftAligned().SetStyle("red"));
+            WrapInPanel(
+                new Rule("[white]Left aligned[/]")
+                    .RuleStyle(Style.Parse("red"))
+                    .LeftAligned());
 
             // Centered title
-            Render(new Rule("[silver]Centered[/]").Centered().SetStyle("green"));
+            WrapInPanel(
+                new Rule("[silver]Centered[/]")
+                    .RuleStyle(Style.Parse("green"))
+                    .Centered());
 
             // Right aligned title
-            Render(new Rule("[grey]Right aligned[/]").RightAligned().SetStyle("blue"));
+            WrapInPanel(
+                new Rule("[grey]Right aligned[/]")
+                    .RuleStyle(Style.Parse("blue"))
+                    .RightAligned());
         }
 
-        private static void Render(Rule rule)
+        private static void WrapInPanel(Rule rule)
         {
-            AnsiConsole.Render(new Panel(rule).Expand().SetBorderStyle(Style.Parse("grey")));
+            AnsiConsole.Render(new Panel(rule).Expand().BorderStyle(Style.Parse("grey")));
             AnsiConsole.WriteLine();
         }
     }

--- a/examples/Tables/Program.cs
+++ b/examples/Tables/Program.cs
@@ -16,8 +16,8 @@ namespace TableExample
         private static Table CreateTable()
         {
             var simple = new Table()
-                .SetBorder(TableBorder.Square)
-                .SetBorderColor(Color.Red)
+                .Border(TableBorder.Square)
+                .BorderColor(Color.Red)
                 .AddColumn(new TableColumn("[u]CDE[/]").Centered())
                 .AddColumn(new TableColumn("[u]FED[/]"))
                 .AddColumn(new TableColumn("[u]IHG[/]"))
@@ -26,8 +26,8 @@ namespace TableExample
                 .AddRow("[blue]Hej[/]", "[yellow]Världen![/]", "");
 
             var second = new Table()
-                .SetBorder(TableBorder.Rounded)
-                .SetBorderColor(Color.Green)
+                .Border(TableBorder.Rounded)
+                .BorderColor(Color.Green)
                 .AddColumn(new TableColumn("[u]Foo[/]"))
                 .AddColumn(new TableColumn("[u]Bar[/]"))
                 .AddColumn(new TableColumn("[u]Baz[/]"))
@@ -37,12 +37,12 @@ namespace TableExample
 
             return new Table()
                 .Centered()
-                .SetBorder(TableBorder.DoubleEdge)
-                .SetHeading("TABLE [yellow]HEADING[/]")
-                .SetFootnote("TABLE [yellow]FOOTNOTE[/]")
-                .AddColumn(new TableColumn(new Panel("[u]ABC[/]").SetBorderColor(Color.Red)))
-                .AddColumn(new TableColumn(new Panel("[u]DEF[/]").SetBorderColor(Color.Green)))
-                .AddColumn(new TableColumn(new Panel("[u]GHI[/]").SetBorderColor(Color.Blue)))
+                .Border(TableBorder.DoubleEdge)
+                .Heading("TABLE [yellow]HEADING[/]")
+                .Footnote("TABLE [yellow]FOOTNOTE[/]")
+                .AddColumn(new TableColumn(new Panel("[u]ABC[/]").BorderColor(Color.Red)))
+                .AddColumn(new TableColumn(new Panel("[u]DEF[/]").BorderColor(Color.Green)))
+                .AddColumn(new TableColumn(new Panel("[u]GHI[/]").BorderColor(Color.Blue)))
                 .AddRow(new Text("Hello").Centered(), new Markup("[red]World![/]"), Text.Empty)
                 .AddRow(second, new Text("Whaaat"), new Text("Lol"))
                 .AddRow(new Markup("[blue]Hej[/]").Centered(), new Markup("[yellow]Världen![/]"), Text.Empty);

--- a/src/Spectre.Console.Tests/Extensions/StyleExtensions.cs
+++ b/src/Spectre.Console.Tests/Extensions/StyleExtensions.cs
@@ -6,10 +6,10 @@ namespace Spectre.Console.Tests
         {
             if (foreground)
             {
-                return style.WithForeground(color);
+                return style.Foreground(color);
             }
 
-            return style.WithBackground(color);
+            return style.Background(color);
         }
     }
 }

--- a/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.Style.cs
+++ b/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.Style.cs
@@ -21,7 +21,7 @@ namespace Spectre.Console.Tests.Unit
             var console = new TestableAnsiConsole(ColorSystem.TrueColor);
 
             // When
-            console.Write("Hello World", Style.WithDecoration(decoration));
+            console.Write("Hello World", new Style().Decoration(decoration));
 
             // Then
             console.Output.ShouldBe(expected);
@@ -36,7 +36,7 @@ namespace Spectre.Console.Tests.Unit
             var console = new TestableAnsiConsole(ColorSystem.TrueColor);
 
             // When
-            console.Write("Hello World", Style.WithDecoration(decoration));
+            console.Write("Hello World", new Style().Decoration(decoration));
 
             // Then
             console.Output.ShouldBe(expected);

--- a/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
+++ b/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
@@ -15,9 +15,10 @@ namespace Spectre.Console.Tests.Unit
             // When
             console.Write(
                 "Hello",
-                Style.WithForeground(Color.RoyalBlue1)
-                     .WithBackground(Color.NavajoWhite1)
-                     .WithDecoration(Decoration.Italic));
+                new Style()
+                    .Foreground(Color.RoyalBlue1)
+                    .Background(Color.NavajoWhite1)
+                    .Decoration(Decoration.Italic));
 
             // Then
             console.Output.ShouldBe("\u001b[3;90;47mHello\u001b[0m");
@@ -32,9 +33,10 @@ namespace Spectre.Console.Tests.Unit
             // When
             console.Write(
                 "Hello",
-                Style.WithForeground(Color.Default)
-                     .WithBackground(Color.NavajoWhite1)
-                     .WithDecoration(Decoration.Italic));
+                new Style()
+                    .Foreground(Color.Default)
+                    .Background(Color.NavajoWhite1)
+                    .Decoration(Decoration.Italic));
 
             // Then
             console.Output.ShouldBe("\u001b[3;47mHello\u001b[0m");
@@ -49,9 +51,10 @@ namespace Spectre.Console.Tests.Unit
             // When
             console.Write(
                 "Hello",
-                Style.WithForeground(Color.RoyalBlue1)
-                     .WithBackground(Color.Default)
-                     .WithDecoration(Decoration.Italic));
+                new Style()
+                    .Foreground(Color.RoyalBlue1)
+                    .Background(Color.Default)
+                    .Decoration(Decoration.Italic));
 
             // Then
             console.Output.ShouldBe("\u001b[3;90mHello\u001b[0m");
@@ -66,9 +69,10 @@ namespace Spectre.Console.Tests.Unit
             // When
             console.Write(
                 "Hello",
-                Style.WithForeground(Color.RoyalBlue1)
-                     .WithBackground(Color.NavajoWhite1)
-                     .WithDecoration(Decoration.None));
+                new Style()
+                    .Foreground(Color.RoyalBlue1)
+                    .Background(Color.NavajoWhite1)
+                    .Decoration(Decoration.None));
 
             // Then
             console.Output.ShouldBe("\u001b[90;47mHello\u001b[0m");
@@ -83,8 +87,8 @@ namespace Spectre.Console.Tests.Unit
                 var console = new TestableAnsiConsole(ColorSystem.Standard, AnsiSupport.Yes);
 
                 // When
-                console.WriteLine("Hello", Style.WithBackground(ConsoleColor.Red));
-                console.WriteLine("World", Style.WithBackground(ConsoleColor.Green));
+                console.WriteLine("Hello", new Style().Background(ConsoleColor.Red));
+                console.WriteLine("World", new Style().Background(ConsoleColor.Green));
 
                 // Then
                 console.Output.NormalizeLineEndings()
@@ -98,7 +102,7 @@ namespace Spectre.Console.Tests.Unit
                 var console = new TestableAnsiConsole(ColorSystem.Standard, AnsiSupport.Yes);
 
                 // When
-                console.WriteLine("Hello\nWorld", Style.WithBackground(ConsoleColor.Red));
+                console.WriteLine("Hello\nWorld", new Style().Background(ConsoleColor.Red));
 
                 // Then
                 console.Output.NormalizeLineEndings()

--- a/src/Spectre.Console.Tests/Unit/BoxBorderTests.cs
+++ b/src/Spectre.Console.Tests/Unit/BoxBorderTests.cs
@@ -14,7 +14,7 @@ namespace Spectre.Console.Tests.Unit
                 public void Should_Return_Safe_Border()
                 {
                     // Given, When
-                    var border = BoxBorder.None.GetSafeBorder(safe: true);
+                    var border = BoxExtensions.GetSafeBorder(BoxBorder.None, safe: true);
 
                     // Then
                     border.ShouldBeSameAs(BoxBorder.None);
@@ -47,7 +47,7 @@ namespace Spectre.Console.Tests.Unit
                 public void Should_Return_Safe_Border()
                 {
                     // Given, When
-                    var border = BoxBorder.Ascii.GetSafeBorder(safe: true);
+                    var border = BoxExtensions.GetSafeBorder(BoxBorder.Ascii, safe: true);
 
                     // Then
                     border.ShouldBeSameAs(BoxBorder.Ascii);
@@ -80,7 +80,7 @@ namespace Spectre.Console.Tests.Unit
                 public void Should_Return_Safe_Border()
                 {
                     // Given, When
-                    var border = BoxBorder.Double.GetSafeBorder(safe: true);
+                    var border = BoxExtensions.GetSafeBorder(BoxBorder.Double, safe: true);
 
                     // Then
                     border.ShouldBeSameAs(BoxBorder.Double);
@@ -113,7 +113,7 @@ namespace Spectre.Console.Tests.Unit
                 public void Should_Return_Safe_Border()
                 {
                     // Given, When
-                    var border = BoxBorder.Heavy.GetSafeBorder(safe: true);
+                    var border = BoxExtensions.GetSafeBorder(BoxBorder.Heavy, safe: true);
 
                     // Then
                     border.ShouldBeSameAs(BoxBorder.Square);
@@ -144,7 +144,7 @@ namespace Spectre.Console.Tests.Unit
             public void Should_Return_Safe_Border()
             {
                 // Given, When
-                var border = BoxBorder.Rounded.GetSafeBorder(safe: true);
+                var border = BoxExtensions.GetSafeBorder(BoxBorder.Rounded, safe: true);
 
                 // Then
                 border.ShouldBeSameAs(BoxBorder.Square);
@@ -174,7 +174,7 @@ namespace Spectre.Console.Tests.Unit
             public void Should_Return_Safe_Border()
             {
                 // Given, When
-                var border = BoxBorder.Square.GetSafeBorder(safe: true);
+                var border = BoxExtensions.GetSafeBorder(BoxBorder.Square, safe: true);
 
                 // Then
                 border.ShouldBeSameAs(BoxBorder.Square);
@@ -203,7 +203,7 @@ namespace Spectre.Console.Tests.Unit
             public static Panel GetPanel()
             {
                 return new Panel("Hello World")
-                    .SetHeader("Greeting");
+                    .Header("Greeting");
             }
         }
     }

--- a/src/Spectre.Console.Tests/Unit/CalendarTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CalendarTests.cs
@@ -127,7 +127,7 @@ namespace Spectre.Console.Tests.Unit
             // Given
             var console = new PlainConsole(width: 80);
             var calendar = new Calendar(2020, 10, 15)
-                .SetCulture("de-DE")
+                .Culture("de-DE")
                 .AddCalendarEvent(new DateTime(2020, 9, 1))
                 .AddCalendarEvent(new DateTime(2020, 10, 3))
                 .AddCalendarEvent(new DateTime(2020, 10, 12));

--- a/src/Spectre.Console.Tests/Unit/PadderTests.cs
+++ b/src/Spectre.Console.Tests/Unit/PadderTests.cs
@@ -17,7 +17,7 @@ namespace Spectre.Console.Tests.Unit
             table.AddRow("Corgi", "Waldo");
 
             // When
-            console.Render(new Padder(table).SetPadding(1, 2, 3, 4));
+            console.Render(new Padder(table).Padding(1, 2, 3, 4));
 
             // Then
             console.Lines.Count.ShouldBe(12);
@@ -48,7 +48,7 @@ namespace Spectre.Console.Tests.Unit
 
             // When
             console.Render(new Padder(table)
-                .SetPadding(1, 2, 3, 4)
+                .Padding(1, 2, 3, 4)
                 .Expand());
 
             // Then
@@ -77,11 +77,11 @@ namespace Spectre.Console.Tests.Unit
             table.AddColumn("Bar", c => c.PadLeft(0).PadRight(0));
             table.AddRow("Baz", "Qux");
             table.AddRow(new Text("Corgi"), new Padder(new Panel("Waldo"))
-                .SetPadding(2, 1, 2, 1));
+                .Padding(2, 1, 2, 1));
 
             // When
             console.Render(new Padder(table)
-                .SetPadding(1, 2, 3, 4)
+                .Padding(1, 2, 3, 4)
                 .Expand());
 
             // Then

--- a/src/Spectre.Console.Tests/Unit/PanelTests.cs
+++ b/src/Spectre.Console.Tests/Unit/PanelTests.cs
@@ -315,8 +315,8 @@ namespace Spectre.Console.Tests.Unit
 
             var panel = new Panel(grid)
                 .Expand().RoundedBorder()
-                .SetBorderStyle(Style.WithForeground(Color.Grey))
-                .SetHeader("Short paths ", Style.WithForeground(Color.Grey));
+                .BorderStyle(new Style().Foreground(Color.Grey))
+                .Header("Short paths ", new Style().Foreground(Color.Grey));
 
             // When
             console.Render(panel);

--- a/src/Spectre.Console.Tests/Unit/RecorderTests.cs
+++ b/src/Spectre.Console.Tests/Unit/RecorderTests.cs
@@ -43,7 +43,7 @@ namespace Spectre.Console.Tests.Unit
                 .AddColumns("[red on black]Foo[/]", "[green bold]Bar[/]", "[blue italic]Qux[/]")
                 .AddRow("[invert underline]Corgi[/]", "[bold strikethrough]Waldo[/]", "[dim]Zap[/]")
                 .AddRow(new Panel("[blue]Hello World[/]")
-                    .SetBorderColor(Color.Red).RoundedBorder()));
+                    .BorderColor(Color.Red).RoundedBorder()));
 
             // When
             var html = recorder.ExportHtml();

--- a/src/Spectre.Console.Tests/Unit/TableTests.cs
+++ b/src/Spectre.Console.Tests/Unit/TableTests.cs
@@ -416,7 +416,7 @@ namespace Spectre.Console.Tests.Unit
             // Given
             var console = new PlainConsole(width: 25);
 
-            var first = new Table().SetBorder(TableBorder.Rounded).SetBorderColor(Color.Red);
+            var first = new Table().Border(TableBorder.Rounded).BorderColor(Color.Red);
             first.AddColumn(new TableColumn("[u]PS1[/]").Centered());
             first.AddColumn(new TableColumn("[u]PS2[/]"));
             first.AddColumn(new TableColumn("[u]PS3[/]"));
@@ -424,7 +424,7 @@ namespace Spectre.Console.Tests.Unit
             first.AddRow("[blue]Bonjour[/]", "[white]le[/]", "[red]monde![/]");
             first.AddRow("[blue]Hej[/]", "[yellow]Världen[/]", string.Empty);
 
-            var second = new Table().SetBorder(TableBorder.Square).SetBorderColor(Color.Green);
+            var second = new Table().Border(TableBorder.Square).BorderColor(Color.Green);
             second.AddColumn(new TableColumn("[u]Foo[/]"));
             second.AddColumn(new TableColumn("[u]Bar[/]"));
             second.AddColumn(new TableColumn("[u]Baz[/]"));
@@ -432,10 +432,10 @@ namespace Spectre.Console.Tests.Unit
             second.AddRow(first, new Text("Whaaat"), new Text("Lolz"));
             second.AddRow("[blue]Hej[/]", "[yellow]Världen[/]", string.Empty);
 
-            var table = new Table().SetBorder(TableBorder.Rounded);
-            table.AddColumn(new TableColumn(new Panel("[u]ABC[/]").SetBorderColor(Color.Red)));
-            table.AddColumn(new TableColumn(new Panel("[u]DEF[/]").SetBorderColor(Color.Green)));
-            table.AddColumn(new TableColumn(new Panel("[u]GHI[/]").SetBorderColor(Color.Blue)));
+            var table = new Table().Border(TableBorder.Rounded);
+            table.AddColumn(new TableColumn(new Panel("[u]ABC[/]").BorderColor(Color.Red)));
+            table.AddColumn(new TableColumn(new Panel("[u]DEF[/]").BorderColor(Color.Green)));
+            table.AddColumn(new TableColumn(new Panel("[u]GHI[/]").BorderColor(Color.Blue)));
             table.AddRow(new Text("Hello").Centered(), new Markup("[red]World[/]"), Text.Empty);
             table.AddRow(second, new Text("Whaat"), new Text("Lol").RightAligned());
             table.AddRow(new Markup("[blue]Hej[/]"), new Markup("[yellow]Världen[/]"), Text.Empty);

--- a/src/Spectre.Console.Tests/Unit/TextTests.cs
+++ b/src/Spectre.Console.Tests/Unit/TextTests.cs
@@ -108,7 +108,7 @@ namespace Spectre.Console.Tests.Unit
             // Given
             var console = new PlainConsole(14);
             var text = new Text("foo pneumonoultramicroscopicsilicovolcanoconiosis bar qux")
-                .SetOverflow(overflow);
+                .Overflow(overflow);
 
             // When
             console.Render(text);

--- a/src/Spectre.Console/AnsiConsole.State.cs
+++ b/src/Spectre.Console/AnsiConsole.State.cs
@@ -14,7 +14,7 @@ namespace Spectre.Console
         public static Color Foreground
         {
             get => CurrentStyle.Foreground;
-            set => CurrentStyle = CurrentStyle.WithForeground(value);
+            set => CurrentStyle = CurrentStyle.Foreground(value);
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Spectre.Console
         public static Color Background
         {
             get => CurrentStyle.Background;
-            set => CurrentStyle = CurrentStyle.WithBackground(value);
+            set => CurrentStyle = CurrentStyle.Background(value);
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Spectre.Console
         public static Decoration Decoration
         {
             get => CurrentStyle.Decoration;
-            set => CurrentStyle = CurrentStyle.WithDecoration(value);
+            set => CurrentStyle = CurrentStyle.Decoration(value);
         }
 
         /// <summary>

--- a/src/Spectre.Console/Extensions/AlignableExtensions.cs
+++ b/src/Spectre.Console/Extensions/AlignableExtensions.cs
@@ -12,7 +12,7 @@ namespace Spectre.Console
         /// <param name="obj">The alignable object.</param>
         /// <param name="alignment">The alignment.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetAlignment<T>(this T obj, Justify alignment)
+        public static T Alignment<T>(this T obj, Justify alignment)
             where T : class, IAlignable
         {
             if (obj is null)

--- a/src/Spectre.Console/Extensions/CalendarExtensions.cs
+++ b/src/Spectre.Console/Extensions/CalendarExtensions.cs
@@ -69,7 +69,7 @@ namespace Spectre.Console
         /// <param name="calendar">The calendar.</param>
         /// <param name="style">The highlight style.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Calendar SetHighlightStyle(this Calendar calendar, Style? style)
+        public static Calendar HighlightStyle(this Calendar calendar, Style? style)
         {
             if (calendar is null)
             {
@@ -86,7 +86,7 @@ namespace Spectre.Console
         /// <param name="calendar">The calendar.</param>
         /// <param name="style">The header style.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Calendar SetHeaderStyle(this Calendar calendar, Style? style)
+        public static Calendar HeaderStyle(this Calendar calendar, Style? style)
         {
             if (calendar is null)
             {

--- a/src/Spectre.Console/Extensions/ExpandableExtensions.cs
+++ b/src/Spectre.Console/Extensions/ExpandableExtensions.cs
@@ -17,7 +17,12 @@ namespace Spectre.Console
         public static T Collapse<T>(this T obj)
             where T : class, IExpandable
         {
-            SetExpand<T>(obj, false);
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Expand = false;
             return obj;
         }
 
@@ -30,19 +35,13 @@ namespace Spectre.Console
         public static T Expand<T>(this T obj)
             where T : class, IExpandable
         {
-            SetExpand<T>(obj, true);
-            return obj;
-        }
-
-        private static void SetExpand<T>(T obj, bool value)
-            where T : class, IExpandable
-        {
             if (obj is null)
             {
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            obj.Expand = value;
+            obj.Expand = true;
+            return obj;
         }
     }
 }

--- a/src/Spectre.Console/Extensions/HasBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/HasBorderExtensions.cs
@@ -8,10 +8,28 @@ namespace Spectre.Console
     public static class HasBorderExtensions
     {
         /// <summary>
+        /// Enables the safe border.
+        /// </summary>
+        /// <typeparam name="T">An object type with a border.</typeparam>
+        /// <param name="obj">The object to enable the safe border for.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static T SafeBorder<T>(this T obj)
+            where T : class, IHasBorder
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.UseSafeBorder = true;
+            return obj;
+        }
+
+        /// <summary>
         /// Disables the safe border.
         /// </summary>
         /// <typeparam name="T">An object type with a border.</typeparam>
-        /// <param name="obj">The object to set the border for.</param>
+        /// <param name="obj">The object to disable the safe border for.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public static T NoSafeBorder<T>(this T obj)
             where T : class, IHasBorder
@@ -29,10 +47,10 @@ namespace Spectre.Console
         /// Sets the border style.
         /// </summary>
         /// <typeparam name="T">An object type with a border.</typeparam>
-        /// <param name="obj">The object to set the border color for.</param>
+        /// <param name="obj">The object to set the border style for.</param>
         /// <param name="style">The border style to set.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetBorderStyle<T>(this T obj, Style style)
+        public static T BorderStyle<T>(this T obj, Style style)
             where T : class, IHasBorder
         {
             if (obj is null)
@@ -51,7 +69,7 @@ namespace Spectre.Console
         /// <param name="obj">The object to set the border color for.</param>
         /// <param name="color">The border color to set.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetBorderColor<T>(this T obj, Color color)
+        public static T BorderColor<T>(this T obj, Color color)
             where T : class, IHasBorder
         {
             if (obj is null)
@@ -59,7 +77,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            obj.BorderStyle = (obj.BorderStyle ?? Style.Plain).WithForeground(color);
+            obj.BorderStyle = (obj.BorderStyle ?? Style.Plain).Foreground(color);
             return obj;
         }
     }

--- a/src/Spectre.Console/Extensions/HasBoxBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/HasBoxBorderExtensions.cs
@@ -8,6 +8,25 @@ namespace Spectre.Console
     public static class HasBoxBorderExtensions
     {
         /// <summary>
+        /// Sets the border.
+        /// </summary>
+        /// <typeparam name="T">An object type with a border.</typeparam>
+        /// <param name="obj">The object to set the border for.</param>
+        /// <param name="border">The border to use.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static T Border<T>(this T obj, BoxBorder border)
+            where T : class, IHasBoxBorder
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Border = border;
+            return obj;
+        }
+
+        /// <summary>
         /// Do not display a border.
         /// </summary>
         /// <typeparam name="T">An object type with a border.</typeparam>
@@ -16,7 +35,7 @@ namespace Spectre.Console
         public static T NoBorder<T>(this T obj)
             where T : class, IHasBoxBorder
         {
-            return SetBorder(obj, BoxBorder.None);
+            return Border(obj, BoxBorder.None);
         }
 
         /// <summary>
@@ -28,7 +47,7 @@ namespace Spectre.Console
         public static T SquareBorder<T>(this T obj)
             where T : class, IHasBoxBorder
         {
-            return SetBorder(obj, BoxBorder.Square);
+            return Border(obj, BoxBorder.Square);
         }
 
         /// <summary>
@@ -40,7 +59,7 @@ namespace Spectre.Console
         public static T AsciiBorder<T>(this T obj)
             where T : class, IHasBoxBorder
         {
-            return SetBorder(obj, BoxBorder.Ascii);
+            return Border(obj, BoxBorder.Ascii);
         }
 
         /// <summary>
@@ -52,7 +71,7 @@ namespace Spectre.Console
         public static T RoundedBorder<T>(this T obj)
             where T : class, IHasBoxBorder
         {
-            return SetBorder(obj, BoxBorder.Rounded);
+            return Border(obj, BoxBorder.Rounded);
         }
 
         /// <summary>
@@ -64,7 +83,7 @@ namespace Spectre.Console
         public static T HeavyBorder<T>(this T obj)
             where T : class, IHasBoxBorder
         {
-            return SetBorder(obj, BoxBorder.Heavy);
+            return Border(obj, BoxBorder.Heavy);
         }
 
         /// <summary>
@@ -76,26 +95,7 @@ namespace Spectre.Console
         public static T DoubleBorder<T>(this T obj)
             where T : class, IHasBoxBorder
         {
-            return SetBorder(obj, BoxBorder.Double);
-        }
-
-        /// <summary>
-        /// Sets the border.
-        /// </summary>
-        /// <typeparam name="T">An object type with a border.</typeparam>
-        /// <param name="obj">The object to set the border for.</param>
-        /// <param name="border">The border to use.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetBorder<T>(this T obj, BoxBorder border)
-            where T : class, IHasBoxBorder
-        {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
-            obj.Border = border;
-            return obj;
+            return Border(obj, BoxBorder.Double);
         }
     }
 }

--- a/src/Spectre.Console/Extensions/HasTableBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/HasTableBorderExtensions.cs
@@ -16,7 +16,7 @@ namespace Spectre.Console
         public static T NoBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.None);
+            return Border(obj, TableBorder.None);
         }
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Spectre.Console
         public static T SquareBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Square);
+            return Border(obj, TableBorder.Square);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Spectre.Console
         public static T AsciiBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Ascii);
+            return Border(obj, TableBorder.Ascii);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Spectre.Console
         public static T Ascii2Border<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Ascii2);
+            return Border(obj, TableBorder.Ascii2);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Spectre.Console
         public static T AsciiDoubleHeadBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.AsciiDoubleHead);
+            return Border(obj, TableBorder.AsciiDoubleHead);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Spectre.Console
         public static T RoundedBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Rounded);
+            return Border(obj, TableBorder.Rounded);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Spectre.Console
         public static T MinimalBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Minimal);
+            return Border(obj, TableBorder.Minimal);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Spectre.Console
         public static T MinimalHeavyHeadBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.MinimalHeavyHead);
+            return Border(obj, TableBorder.MinimalHeavyHead);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Spectre.Console
         public static T MinimalDoubleHeadBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.MinimalDoubleHead);
+            return Border(obj, TableBorder.MinimalDoubleHead);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Spectre.Console
         public static T SimpleBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Simple);
+            return Border(obj, TableBorder.Simple);
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace Spectre.Console
         public static T SimpleHeavyBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.SimpleHeavy);
+            return Border(obj, TableBorder.SimpleHeavy);
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Spectre.Console
         public static T HorizontalBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Horizontal);
+            return Border(obj, TableBorder.Horizontal);
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Spectre.Console
         public static T HeavyBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Heavy);
+            return Border(obj, TableBorder.Heavy);
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Spectre.Console
         public static T HeavyEdgeBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.HeavyEdge);
+            return Border(obj, TableBorder.HeavyEdge);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Spectre.Console
         public static T HeavyHeadBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.HeavyHead);
+            return Border(obj, TableBorder.HeavyHead);
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Spectre.Console
         public static T DoubleBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Double);
+            return Border(obj, TableBorder.Double);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Spectre.Console
         public static T DoubleEdgeBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.DoubleEdge);
+            return Border(obj, TableBorder.DoubleEdge);
         }
 
         /// <summary>
@@ -220,7 +220,7 @@ namespace Spectre.Console
         public static T MarkdownBorder<T>(this T obj)
             where T : class, IHasTableBorder
         {
-            return SetBorder(obj, TableBorder.Markdown);
+            return Border(obj, TableBorder.Markdown);
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Spectre.Console
         /// <param name="obj">The object to set the border for.</param>
         /// <param name="border">The border to use.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetBorder<T>(this T obj, TableBorder border)
+        public static T Border<T>(this T obj, TableBorder border)
             where T : class, IHasTableBorder
         {
             if (obj is null)

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteAlignableExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteAlignableExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="IAlignable"/>.
+    /// </summary>
+    public static class ObsoleteAlignableExtensions
+    {
+        /// <summary>
+        /// Sets the alignment for an <see cref="IAlignable"/> object.
+        /// </summary>
+        /// <typeparam name="T">The alignable object type.</typeparam>
+        /// <param name="obj">The alignable object.</param>
+        /// <param name="alignment">The alignment.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Alignment(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetAlignment<T>(this T obj, Justify alignment)
+            where T : class, IAlignable
+        {
+            if (obj is null)
+            {
+                throw new System.ArgumentNullException(nameof(obj));
+            }
+
+            obj.Alignment = alignment;
+            return obj;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteCalendarExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteCalendarExtensions.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="Calendar"/>.
+    /// </summary>
+    public static class ObsoleteCalendarExtensions
+    {
+        /// <summary>
+        /// Sets the calendar's highlight <see cref="Style"/>.
+        /// </summary>
+        /// <param name="calendar">The calendar.</param>
+        /// <param name="style">The highlight style.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use HighlightStyle(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Calendar SetHighlightStyle(this Calendar calendar, Style? style)
+        {
+            if (calendar is null)
+            {
+                throw new ArgumentNullException(nameof(calendar));
+            }
+
+            calendar.HightlightStyle = style ?? Style.Plain;
+            return calendar;
+        }
+
+        /// <summary>
+        /// Sets the calendar's header <see cref="Style"/>.
+        /// </summary>
+        /// <param name="calendar">The calendar.</param>
+        /// <param name="style">The header style.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use HeaderStyle(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Calendar SetHeaderStyle(this Calendar calendar, Style? style)
+        {
+            if (calendar is null)
+            {
+                throw new ArgumentNullException(nameof(calendar));
+            }
+
+            calendar.HeaderStyle = style ?? Style.Plain;
+            return calendar;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasBorderExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="IHasBorder"/>.
+    /// </summary>
+    public static class ObsoleteHasBorderExtensions
+    {
+        /// <summary>
+        /// Sets the border style.
+        /// </summary>
+        /// <typeparam name="T">An object type with a border.</typeparam>
+        /// <param name="obj">The object to set the border color for.</param>
+        /// <param name="style">The border style to set.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use BorderStyle(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetBorderStyle<T>(this T obj, Style style)
+            where T : class, IHasBorder
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.BorderStyle = style;
+            return obj;
+        }
+
+        /// <summary>
+        /// Sets the border color.
+        /// </summary>
+        /// <typeparam name="T">An object type with a border.</typeparam>
+        /// <param name="obj">The object to set the border color for.</param>
+        /// <param name="color">The border color to set.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use BorderColor(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetBorderColor<T>(this T obj, Color color)
+            where T : class, IHasBorder
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.BorderStyle = (obj.BorderStyle ?? Style.Plain).Foreground(color);
+            return obj;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasBoxBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasBoxBorderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="IHasBoxBorder"/>.
+    /// </summary>
+    public static class ObsoleteHasBoxBorderExtensions
+    {
+        /// <summary>
+        /// Sets the border.
+        /// </summary>
+        /// <typeparam name="T">An object type with a border.</typeparam>
+        /// <param name="obj">The object to set the border for.</param>
+        /// <param name="border">The border to use.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Border(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetBorder<T>(this T obj, BoxBorder border)
+            where T : class, IHasBoxBorder
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Border = border;
+            return obj;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasCultureExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasCultureExtensions.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Globalization;
 
 namespace Spectre.Console
@@ -6,7 +7,7 @@ namespace Spectre.Console
     /// <summary>
     /// Contains extension methods for <see cref="IHasCulture"/>.
     /// </summary>
-    public static class HasCultureExtensions
+    public static class ObsoleteHasCultureExtensions
     {
         /// <summary>
         /// Sets the culture.
@@ -15,7 +16,9 @@ namespace Spectre.Console
         /// <param name="obj">The object to set the culture for.</param>
         /// <param name="culture">The culture to set.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T Culture<T>(this T obj, CultureInfo culture)
+        [Obsolete("Use Culture(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetCulture<T>(this T obj, CultureInfo culture)
             where T : class, IHasCulture
         {
             if (obj is null)
@@ -39,15 +42,18 @@ namespace Spectre.Console
         /// <param name="obj">The object to set the culture for.</param>
         /// <param name="name">The culture to set.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T Culture<T>(this T obj, string name)
+        [Obsolete("Use Culture(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetCulture<T>(this T obj, string name)
             where T : class, IHasCulture
         {
-            if (name is null)
+            if (obj is null)
             {
-                throw new ArgumentNullException(nameof(name));
+                throw new ArgumentNullException(nameof(obj));
             }
 
-            return Culture(obj, CultureInfo.GetCultureInfo(name));
+            obj.Culture = CultureInfo.GetCultureInfo(name);
+            return obj;
         }
 
         /// <summary>
@@ -55,12 +61,20 @@ namespace Spectre.Console
         /// </summary>
         /// <typeparam name="T">An object type with a culture.</typeparam>
         /// <param name="obj">The object to set the culture for.</param>
-        /// <param name="culture">The culture to set.</param>
+        /// <param name="name">The culture to set.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T Culture<T>(this T obj, int culture)
+        [Obsolete("Use Culture(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetCulture<T>(this T obj, int name)
             where T : class, IHasCulture
         {
-            return Culture(obj, CultureInfo.GetCultureInfo(culture));
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Culture = CultureInfo.GetCultureInfo(name);
+            return obj;
         }
     }
 }

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasTableBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteHasTableBorderExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="IHasTableBorder"/>.
+    /// </summary>
+    public static class ObsoleteHasTableBorderExtensions
+    {
+        /// <summary>
+        /// Sets the border.
+        /// </summary>
+        /// <typeparam name="T">An object type with a border.</typeparam>
+        /// <param name="obj">The object to set the border for.</param>
+        /// <param name="border">The border to use.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Border(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetBorder<T>(this T obj, TableBorder border)
+            where T : class, IHasTableBorder
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Border = border;
+            return obj;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteOverflowableExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteOverflowableExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="IOverflowable"/>.
+    /// </summary>
+    public static class ObsoleteOverflowableExtensions
+    {
+        /// <summary>
+        /// Sets the overflow strategy.
+        /// </summary>
+        /// <typeparam name="T">An object implementing <see cref="IOverflowable"/>.</typeparam>
+        /// <param name="obj">The overflowable object instance.</param>
+        /// <param name="overflow">The overflow strategy to use.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Overflow(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetOverflow<T>(this T obj, Overflow overflow)
+            where T : class, IOverflowable
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Overflow = overflow;
+            return obj;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoletePaddableExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoletePaddableExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="IPaddable"/>.
+    /// </summary>
+    public static class ObsoletePaddableExtensions
+    {
+        /// <summary>
+        /// Sets the left and right padding.
+        /// </summary>
+        /// <typeparam name="T">An object implementing <see cref="IPaddable"/>.</typeparam>
+        /// <param name="obj">The paddable object instance.</param>
+        /// <param name="left">The left padding to apply.</param>
+        /// <param name="top">The top padding to apply.</param>
+        /// <param name="right">The right padding to apply.</param>
+        /// <param name="bottom">The bottom padding to apply.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Padding(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetPadding<T>(this T obj, int left, int top, int right, int bottom)
+            where T : class, IPaddable
+        {
+            return SetPadding(obj, new Padding(left, top, right, bottom));
+        }
+
+        /// <summary>
+        /// Sets the padding.
+        /// </summary>
+        /// <typeparam name="T">An object implementing <see cref="IPaddable"/>.</typeparam>
+        /// <param name="obj">The paddable object instance.</param>
+        /// <param name="padding">The padding to apply.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Padding(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static T SetPadding<T>(this T obj, Padding padding)
+            where T : class, IPaddable
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.Padding = padding;
+            return obj;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoletePanelExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoletePanelExtensions.cs
@@ -1,0 +1,58 @@
+using System;
+using System.ComponentModel;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="Panel"/>.
+    /// </summary>
+    public static class ObsoletePanelExtensions
+    {
+        /// <summary>
+        /// Sets the panel header.
+        /// </summary>
+        /// <param name="panel">The panel.</param>
+        /// <param name="text">The header text.</param>
+        /// <param name="style">The header style.</param>
+        /// <param name="alignment">The header alignment.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Header(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Panel SetHeader(this Panel panel, string text, Style? style = null, Justify? alignment = null)
+        {
+            if (panel is null)
+            {
+                throw new ArgumentNullException(nameof(panel));
+            }
+
+            if (text is null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            style ??= panel.Header?.Style;
+            alignment ??= panel.Header?.Alignment;
+
+            return SetHeader(panel, new PanelHeader(text, style, alignment));
+        }
+
+        /// <summary>
+        /// Sets the panel header.
+        /// </summary>
+        /// <param name="panel">The panel.</param>
+        /// <param name="header">The header to use.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Header(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Panel SetHeader(this Panel panel, PanelHeader header)
+        {
+            if (panel is null)
+            {
+                throw new ArgumentNullException(nameof(panel));
+            }
+
+            panel.Header = header;
+            return panel;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteRuleExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteRuleExtensions.cs
@@ -1,11 +1,12 @@
-using System;
+﻿using System;
+using System.ComponentModel;
 
 namespace Spectre.Console
 {
     /// <summary>
     /// Contains extension methods for <see cref="RuleExtensions"/>.
     /// </summary>
-    public static class RuleExtensions
+    public static class ObsoleteRuleExtensions
     {
         /// <summary>
         /// Sets the rule title.
@@ -13,7 +14,9 @@ namespace Spectre.Console
         /// <param name="rule">The rule.</param>
         /// <param name="title">The title.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Rule RuleTitle(this Rule rule, string title)
+        [Obsolete("Use Title(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Rule SetTitle(this Rule rule, string title)
         {
             if (rule is null)
             {
@@ -35,7 +38,9 @@ namespace Spectre.Console
         /// <param name="rule">The rule.</param>
         /// <param name="style">The rule style.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Rule RuleStyle(this Rule rule, Style style)
+        [Obsolete("Use Style(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Rule SetStyle(this Rule rule, Style style)
         {
             if (rule is null)
             {

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteStringExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteStringExtensions.cs
@@ -1,25 +1,23 @@
+using System;
+using System.ComponentModel;
+
 namespace Spectre.Console
 {
     /// <summary>
     /// Contains extension methods for <see cref="string"/>.
     /// </summary>
-    public static class StringExtensions
+    public static class ObsoleteStringExtensions
     {
         /// <summary>
         /// Escapes text so that it won’t be interpreted as markup.
         /// </summary>
         /// <param name="text">The text to escape.</param>
         /// <returns>A string that is safe to use in markup.</returns>
-        public static string EscapeMarkup(this string text)
+        [Obsolete("Use EscapeMarkup(..) instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static string SafeMarkup(this string text)
         {
-            if (text == null)
-            {
-                return string.Empty;
-            }
-
-            return text
-                .Replace("[", "[[")
-                .Replace("]", "]]");
+            return text.EscapeMarkup();
         }
     }
 }

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteStyleExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteStyleExtensions.cs
@@ -1,11 +1,12 @@
-using System;
+﻿using System;
+using System.ComponentModel;
 
 namespace Spectre.Console
 {
     /// <summary>
     /// Contains extension methods for <see cref="Style"/>.
     /// </summary>
-    public static class StyleExtensions
+    public static class ObsoleteStyleExtensions
     {
         /// <summary>
         /// Creates a new style from the specified one with
@@ -14,7 +15,9 @@ namespace Spectre.Console
         /// <param name="style">The style.</param>
         /// <param name="color">The foreground color.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Style Foreground(this Style style, Color color)
+        [Obsolete("Use Foreground(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Style WithForeground(this Style style, Color color)
         {
             if (style is null)
             {
@@ -34,7 +37,9 @@ namespace Spectre.Console
         /// <param name="style">The style.</param>
         /// <param name="color">The background color.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Style Background(this Style style, Color color)
+        [Obsolete("Use Background(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Style WithBackground(this Style style, Color color)
         {
             if (style is null)
             {
@@ -54,7 +59,9 @@ namespace Spectre.Console
         /// <param name="style">The style.</param>
         /// <param name="decoration">The text decoration.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Style Decoration(this Style style, Decoration decoration)
+        [Obsolete("Use Decoration(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Style WithDecoration(this Style style, Decoration decoration)
         {
             if (style is null)
             {
@@ -74,7 +81,9 @@ namespace Spectre.Console
         /// <param name="style">The style.</param>
         /// <param name="link">The link.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Style Link(this Style style, string link)
+        [Obsolete("Use Link(..) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static Style WithLink(this Style style, string link)
         {
             if (style is null)
             {

--- a/src/Spectre.Console/Extensions/Obsolete/ObsoleteTableExtensions.cs
+++ b/src/Spectre.Console/Extensions/Obsolete/ObsoleteTableExtensions.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using Spectre.Console.Internal;
+using Spectre.Console.Rendering;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Contains extension methods for <see cref="Table"/>.
+    /// </summary>
+    public static class ObsoleteTableExtensions
+    {
+        /// <summary>
+        /// Sets the table width.
+        /// </summary>
+        /// <param name="table">The table.</param>
+        /// <param name="width">The width.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Width(..) instead.")]
+        public static Table SetWidth(this Table table, int width)
+        {
+            if (table is null)
+            {
+                throw new ArgumentNullException(nameof(table));
+            }
+
+            table.Width = width;
+            return table;
+        }
+
+        /// <summary>
+        /// Sets the table heading.
+        /// </summary>
+        /// <param name="table">The table.</param>
+        /// <param name="text">The heading.</param>
+        /// <param name="style">The style.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Heading(..) instead.")]
+        public static Table SetHeading(this Table table, string text, Style? style = null)
+        {
+            if (table is null)
+            {
+                throw new ArgumentNullException(nameof(table));
+            }
+
+            if (text is null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            return SetHeading(table, new TableTitle(text, style));
+        }
+
+        /// <summary>
+        /// Sets the table heading.
+        /// </summary>
+        /// <param name="table">The table.</param>
+        /// <param name="heading">The heading.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Heading(..) instead.")]
+        public static Table SetHeading(this Table table, TableTitle heading)
+        {
+            if (table is null)
+            {
+                throw new ArgumentNullException(nameof(table));
+            }
+
+            table.Heading = heading;
+            return table;
+        }
+
+        /// <summary>
+        /// Sets the table footnote.
+        /// </summary>
+        /// <param name="table">The table.</param>
+        /// <param name="text">The footnote.</param>
+        /// <param name="style">The style.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Footnote(..) instead.")]
+        public static Table SetFootnote(this Table table, string text, Style? style = null)
+        {
+            if (table is null)
+            {
+                throw new ArgumentNullException(nameof(table));
+            }
+
+            if (text is null)
+            {
+                throw new ArgumentNullException(nameof(text));
+            }
+
+            return SetFootnote(table, new TableTitle(text, style));
+        }
+
+        /// <summary>
+        /// Sets the table footnote.
+        /// </summary>
+        /// <param name="table">The table.</param>
+        /// <param name="footnote">The footnote.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        [Obsolete("Use Footnote(..) instead.")]
+        public static Table SetFootnote(this Table table, TableTitle footnote)
+        {
+            if (table is null)
+            {
+                throw new ArgumentNullException(nameof(table));
+            }
+
+            table.Footnote = footnote;
+            return table;
+        }
+    }
+}

--- a/src/Spectre.Console/Extensions/OverflowableExtensions.cs
+++ b/src/Spectre.Console/Extensions/OverflowableExtensions.cs
@@ -21,7 +21,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetOverflow(obj, Overflow.Fold);
+            return Overflow(obj, Console.Overflow.Fold);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetOverflow(obj, Overflow.Crop);
+            return Overflow(obj, Console.Overflow.Crop);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetOverflow(obj, Overflow.Ellipsis);
+            return Overflow(obj, Console.Overflow.Ellipsis);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Spectre.Console
         /// <param name="obj">The overflowable object instance.</param>
         /// <param name="overflow">The overflow strategy to use.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetOverflow<T>(this T obj, Overflow overflow)
+        public static T Overflow<T>(this T obj, Overflow overflow)
             where T : class, IOverflowable
         {
             if (obj is null)

--- a/src/Spectre.Console/Extensions/PaddableExtensions.cs
+++ b/src/Spectre.Console/Extensions/PaddableExtensions.cs
@@ -22,7 +22,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetPadding(obj, new Padding(left, obj.Padding.Top, obj.Padding.Right, obj.Padding.Bottom));
+            return Padding(obj, new Padding(left, obj.Padding.Top, obj.Padding.Right, obj.Padding.Bottom));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetPadding(obj, new Padding(obj.Padding.Left, top, obj.Padding.Right, obj.Padding.Bottom));
+            return Padding(obj, new Padding(obj.Padding.Left, top, obj.Padding.Right, obj.Padding.Bottom));
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetPadding(obj, new Padding(obj.Padding.Left, obj.Padding.Top, right, obj.Padding.Bottom));
+            return Padding(obj, new Padding(obj.Padding.Left, obj.Padding.Top, right, obj.Padding.Bottom));
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            return SetPadding(obj, new Padding(obj.Padding.Left, obj.Padding.Top, obj.Padding.Right, bottom));
+            return Padding(obj, new Padding(obj.Padding.Left, obj.Padding.Top, obj.Padding.Right, bottom));
         }
 
         /// <summary>
@@ -89,10 +89,10 @@ namespace Spectre.Console
         /// <param name="right">The right padding to apply.</param>
         /// <param name="bottom">The bottom padding to apply.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetPadding<T>(this T obj, int left, int top, int right, int bottom)
+        public static T Padding<T>(this T obj, int left, int top, int right, int bottom)
             where T : class, IPaddable
         {
-            return SetPadding(obj, new Padding(left, top, right, bottom));
+            return Padding(obj, new Padding(left, top, right, bottom));
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Spectre.Console
         /// <param name="obj">The paddable object instance.</param>
         /// <param name="padding">The padding to apply.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static T SetPadding<T>(this T obj, Padding padding)
+        public static T Padding<T>(this T obj, Padding padding)
             where T : class, IPaddable
         {
             if (obj is null)

--- a/src/Spectre.Console/Extensions/PanelExtensions.cs
+++ b/src/Spectre.Console/Extensions/PanelExtensions.cs
@@ -15,7 +15,7 @@ namespace Spectre.Console
         /// <param name="style">The header style.</param>
         /// <param name="alignment">The header alignment.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Panel SetHeader(this Panel panel, string text, Style? style = null, Justify? alignment = null)
+        public static Panel Header(this Panel panel, string text, Style? style = null, Justify? alignment = null)
         {
             if (panel is null)
             {
@@ -27,7 +27,69 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(text));
             }
 
-            return SetHeader(panel, new PanelHeader(text, style, alignment));
+            style ??= panel.Header?.Style;
+            alignment ??= panel.Header?.Alignment;
+
+            return Header(panel, new PanelHeader(text, style, alignment));
+        }
+
+        /// <summary>
+        /// Sets the panel header style.
+        /// </summary>
+        /// <param name="panel">The panel.</param>
+        /// <param name="style">The header style.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static Panel HeaderStyle(this Panel panel, Style style)
+        {
+            if (panel is null)
+            {
+                throw new ArgumentNullException(nameof(panel));
+            }
+
+            if (style is null)
+            {
+                throw new ArgumentNullException(nameof(style));
+            }
+
+            if (panel.Header != null)
+            {
+                // Update existing style
+                panel.Header.Style = style;
+            }
+            else
+            {
+                // Create header
+                Header(panel, string.Empty, style, null);
+            }
+
+            return panel;
+        }
+
+        /// <summary>
+        /// Sets the panel header alignment.
+        /// </summary>
+        /// <param name="panel">The panel.</param>
+        /// <param name="alignment">The header alignment.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static Panel HeaderAlignment(this Panel panel, Justify alignment)
+        {
+            if (panel is null)
+            {
+                throw new ArgumentNullException(nameof(panel));
+            }
+
+            if (panel.Header != null)
+            {
+                // Update existing style
+                panel.Header.Alignment = alignment;
+            }
+            else
+            {
+                // Create header
+                Header(panel, string.Empty, null, alignment);
+            }
+
+            return panel;
         }
 
         /// <summary>
@@ -36,7 +98,7 @@ namespace Spectre.Console
         /// <param name="panel">The panel.</param>
         /// <param name="header">The header to use.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Panel SetHeader(this Panel panel, PanelHeader header)
+        public static Panel Header(this Panel panel, PanelHeader header)
         {
             if (panel is null)
             {

--- a/src/Spectre.Console/Extensions/TableBorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/TableBorderExtensions.cs
@@ -5,7 +5,7 @@ namespace Spectre.Console.Rendering
     /// <summary>
     /// Contains extension methods for <see cref="TableBorder"/>.
     /// </summary>
-    public static class BorderExtensions
+    public static class TableBorderExtensions
     {
         /// <summary>
         /// Gets the safe border for a border.

--- a/src/Spectre.Console/Extensions/TableExtensions.cs
+++ b/src/Spectre.Console/Extensions/TableExtensions.cs
@@ -134,7 +134,7 @@ namespace Spectre.Console
         /// <param name="table">The table.</param>
         /// <param name="width">The width.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Table SetWidth(this Table table, int width)
+        public static Table Width(this Table table, int width)
         {
             if (table is null)
             {
@@ -184,7 +184,7 @@ namespace Spectre.Console
         /// <param name="text">The heading.</param>
         /// <param name="style">The style.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Table SetHeading(this Table table, string text, Style? style = null)
+        public static Table Heading(this Table table, string text, Style? style = null)
         {
             if (table is null)
             {
@@ -196,7 +196,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(text));
             }
 
-            return SetHeading(table, new TableTitle(text, style));
+            return Heading(table, new TableTitle(text, style));
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Spectre.Console
         /// <param name="table">The table.</param>
         /// <param name="heading">The heading.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Table SetHeading(this Table table, TableTitle heading)
+        public static Table Heading(this Table table, TableTitle heading)
         {
             if (table is null)
             {
@@ -223,7 +223,7 @@ namespace Spectre.Console
         /// <param name="text">The footnote.</param>
         /// <param name="style">The style.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Table SetFootnote(this Table table, string text, Style? style = null)
+        public static Table Footnote(this Table table, string text, Style? style = null)
         {
             if (table is null)
             {
@@ -235,7 +235,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(text));
             }
 
-            return SetFootnote(table, new TableTitle(text, style));
+            return Footnote(table, new TableTitle(text, style));
         }
 
         /// <summary>
@@ -244,7 +244,7 @@ namespace Spectre.Console
         /// <param name="table">The table.</param>
         /// <param name="footnote">The footnote.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static Table SetFootnote(this Table table, TableTitle footnote)
+        public static Table Footnote(this Table table, TableTitle footnote)
         {
             if (table is null)
             {

--- a/src/Spectre.Console/Style.cs
+++ b/src/Spectre.Console/Style.cs
@@ -61,6 +61,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="color">The foreground color.</param>
         /// <returns>A new <see cref="Style"/> with the specified foreground color.</returns>
+        [Obsolete("Use ctor(..) instead")]
         public static Style WithForeground(Color color)
         {
             return new Style(foreground: color);
@@ -71,6 +72,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="color">The background color.</param>
         /// <returns>A new <see cref="Style"/> with the specified background color.</returns>
+        [Obsolete("Use ctor(..) instead")]
         public static Style WithBackground(Color color)
         {
             return new Style(background: color);
@@ -81,6 +83,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="decoration">The text decoration.</param>
         /// <returns>A new <see cref="Style"/> with the specified text decoration.</returns>
+        [Obsolete("Use ctor(..) instead")]
         public static Style WithDecoration(Decoration decoration)
         {
             return new Style(decoration: decoration);
@@ -91,6 +94,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="link">The link.</param>
         /// <returns>A new <see cref="Style"/> with the specified link.</returns>
+        [Obsolete("Use ctor(..) instead")]
         public static Style WithLink(string link)
         {
             return new Style(link: link);
@@ -143,7 +147,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="style">The style string.</param>
         [SuppressMessage("Usage", "CA2225:Operator overloads have named alternates")]
-        public static explicit operator Style(string style)
+        public static implicit operator Style(string style)
         {
             return Parse(style);
         }

--- a/src/Spectre.Console/Widgets/Panel.cs
+++ b/src/Spectre.Console/Widgets/Panel.cs
@@ -72,7 +72,7 @@ namespace Spectre.Console
         /// <inheritdoc/>
         protected override IEnumerable<Segment> Render(RenderContext context, int maxWidth)
         {
-            var border = Border.GetSafeBorder((context.LegacyConsole || !context.Unicode) && UseSafeBorder);
+            var border = BoxExtensions.GetSafeBorder(Border, (context.LegacyConsole || !context.Unicode) && UseSafeBorder);
             var borderStyle = BorderStyle ?? Style.Plain;
 
             var child = new Padder(_child, Padding);

--- a/src/Spectre.Console/Widgets/Table.cs
+++ b/src/Spectre.Console/Widgets/Table.cs
@@ -408,8 +408,8 @@ namespace Spectre.Console
             }
 
             var paragraph = new Markup(header.Text.Capitalize(), header.Style ?? defaultStyle)
-                .SetAlignment(Justify.Center)
-                .SetOverflow(Overflow.Ellipsis);
+                .Alignment(Justify.Center)
+                .Overflow(Overflow.Ellipsis);
 
             var items = new List<Segment>();
             items.AddRange(((IRenderable)paragraph).Render(context, tableWidth));

--- a/src/Spectre.Console/Widgets/TableColumn.cs
+++ b/src/Spectre.Console/Widgets/TableColumn.cs
@@ -41,7 +41,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="text">The table column text.</param>
         public TableColumn(string text)
-            : this(new Markup(text).SetOverflow(Overflow.Ellipsis))
+            : this(new Markup(text).Overflow(Overflow.Ellipsis))
         {
         }
 


### PR DESCRIPTION
* Added implicit conversion from string to Style.
* Removed the verbs from all extension methods that manipulate properties which makes the API more succinct and easier to read.

As a good OSS citizen, I've obsoleted the old methods with a warning for now, so this shouldn't break anyone using the old methods.