### PR TITLE
Add Padding extension

### DIFF
--- a/docs/input/widgets/table.md
+++ b/docs/input/widgets/table.md
@@ -100,12 +100,16 @@ table.Columns[0].RightAligned();
 ## Padding
 
 ```csharp
-// Set left and right padding
-table.Columns[0].Padding(left: 3, right: 5);
-
 // Set padding individually
 table.Columns[0].PadLeft(3);
 table.Columns[0].PadRight(5);
+
+// Or chained together
+table.Columns[0].PadLeft(3).PadRight(5);
+
+// Or with the shorthand method if the left and right 
+// padding are identical. Vertical padding is ignored.
+table.Columns[0].Padding(4, 0);
 ```
 
 ## Disable column wrapping

--- a/src/Spectre.Console.Tests/Unit/PadderTests.cs
+++ b/src/Spectre.Console.Tests/Unit/PadderTests.cs
@@ -77,7 +77,7 @@ namespace Spectre.Console.Tests.Unit
             table.AddColumn("Bar", c => c.PadLeft(0).PadRight(0));
             table.AddRow("Baz", "Qux");
             table.AddRow(new Text("Corgi"), new Padder(new Panel("Waldo"))
-                .Padding(2, 1, 2, 1));
+                .Padding(2, 1));
 
             // When
             console.Render(new Padder(table)

--- a/src/Spectre.Console/Extensions/PaddableExtensions.cs
+++ b/src/Spectre.Console/Extensions/PaddableExtensions.cs
@@ -80,7 +80,7 @@ namespace Spectre.Console
         }
 
         /// <summary>
-        /// Sets the left and right padding.
+        /// Sets the left, top, right and bottom padding.
         /// </summary>
         /// <typeparam name="T">An object implementing <see cref="IPaddable"/>.</typeparam>
         /// <param name="obj">The paddable object instance.</param>
@@ -93,6 +93,20 @@ namespace Spectre.Console
             where T : class, IPaddable
         {
             return Padding(obj, new Padding(left, top, right, bottom));
+        }
+
+        /// <summary>
+        /// Sets the horizontal and vertical padding.
+        /// </summary>
+        /// <typeparam name="T">An object implementing <see cref="IPaddable"/>.</typeparam>
+        /// <param name="obj">The paddable object instance.</param>
+        /// <param name="horizontal">The left and right padding.</param>
+        /// <param name="vertical">The top and bottom padding.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static T Padding<T>(this T obj, int horizontal, int vertical)
+            where T : class, IPaddable
+        {
+            return Padding(obj, new Padding(horizontal, vertical));
         }
 
         /// <summary>


### PR DESCRIPTION
Add extension method for specifying horizontal and vertical padding.
Similar constructor for `Padding` already existed.

Update documentation for table column appearance (padding).

Update
`Should_Render_Padded_Object_Correctly_When_Nested_Within_Other_Object`
test to use new extension method.