### PR TITLE
Interlaced Canvas Graphics

### DIFF
--- a/examples/Canvas/Program.cs
+++ b/examples/Canvas/Program.cs
@@ -24,12 +24,21 @@ namespace CanvasExample
             });
 
             image.MaxWidth(32);
-            Render(image, "Image from file (16 wide)");
+            Render(image, "Image from file (32 wide)");
 
-            // Draw image again, but without render width
-            image.NoMaxWidth();
-            image.Mutate(ctx => ctx.Grayscale().Rotate(-45).EntropyCrop());
-            Render(image, "Image from file (fit, greyscale, rotated)");
+
+            var image2 = new CanvasImage("cake.png", CanvasRenderMode.Interlaced);
+
+            // Draw image without render width
+            image2.NoMaxWidth();
+            image2.BilinearResampler();
+            image2.Mutate(ctx => ctx.Grayscale().Rotate(-45).EntropyCrop());
+            image2.Mutate(c =>
+            {
+                var (width, height) = c.GetCurrentSize();
+                c.Resize(width / 2, height);
+            });
+            Render(image2, "Image from file (fit, greyscale, rotated)");
         }
 
         private static void Render(IRenderable canvas, string title)

--- a/examples/Canvas/Program.cs
+++ b/examples/Canvas/Program.cs
@@ -16,8 +16,13 @@ namespace CanvasExample
             // This requires the "Spectre.Console.ImageSharp" NuGet package.
             var image = new CanvasImage("cake.png", CanvasRenderMode.Interlaced);
 
-            image.Mutate(c => c.Resize(32, 64));
             image.BilinearResampler();
+            image.Mutate(c =>
+            {
+                var (width, height) = c.GetCurrentSize();
+                c.Resize(width / 2, height);
+            });
+
             image.MaxWidth(32);
             Render(image, "Image from file (16 wide)");
 

--- a/examples/Canvas/Program.cs
+++ b/examples/Canvas/Program.cs
@@ -14,7 +14,8 @@ namespace CanvasExample
 
             // Draw an image using CanvasImage powered by ImageSharp.
             // This requires the "Spectre.Console.ImageSharp" NuGet package.
-            var image = new CanvasImage("cake.png");
+            var image = new CanvasImage("cake.png", CanvasRenderMode.Interlaced);
+
             image.Mutate(c => c.Resize(32, 64));
             image.BilinearResampler();
             image.MaxWidth(32);

--- a/examples/Canvas/Program.cs
+++ b/examples/Canvas/Program.cs
@@ -15,8 +15,9 @@ namespace CanvasExample
             // Draw an image using CanvasImage powered by ImageSharp.
             // This requires the "Spectre.Console.ImageSharp" NuGet package.
             var image = new CanvasImage("cake.png");
+            image.Mutate(c => c.Resize(32, 64));
             image.BilinearResampler();
-            image.MaxWidth(16);
+            image.MaxWidth(32);
             Render(image, "Image from file (16 wide)");
 
             // Draw image again, but without render width

--- a/src/Spectre.Console.ImageSharp/CanvasImage.cs
+++ b/src/Spectre.Console.ImageSharp/CanvasImage.cs
@@ -46,10 +46,13 @@ namespace Spectre.Console
         /// Initializes a new instance of the <see cref="CanvasImage"/> class.
         /// </summary>
         /// <param name="filename">The image filename.</param>
-        public CanvasImage(string filename)
+        public CanvasImage(string filename, CanvasRenderMode renderMode = CanvasRenderMode.Block)
         {
             Image = SixLabors.ImageSharp.Image.Load<Rgba32>(filename);
+            RenderMode = renderMode;
         }
+
+        public CanvasRenderMode RenderMode { get; }
 
         /// <inheritdoc/>
         protected override Measurement Measure(RenderContext context, int maxWidth)
@@ -98,7 +101,7 @@ namespace Spectre.Console
                 image.Mutate(i => i.Resize(width, height, resampler));
             }
 
-            var canvas = new Canvas(width, height)
+            var canvas = new Canvas(width, height, RenderMode)
             {
                 MaxWidth = MaxWidth,
                 PixelWidth = PixelWidth,

--- a/src/Spectre.Console/Widgets/CanvasRenderMode.cs
+++ b/src/Spectre.Console/Widgets/CanvasRenderMode.cs
@@ -1,0 +1,8 @@
+namespace Spectre.Console
+{
+    public enum CanvasRenderMode
+    {
+        Block,
+        Interlaced
+    }
+}


### PR DESCRIPTION
Proof of Concept PR for interlaced graphics.
The idea is that Canvas has a `CanvasRenderMode` which decides if it renders using a full ' ' space block, or if it uses a '▄' char with fore and back-color to get two pixels in one char.

No idea if this is something that is of value for the project, but it was fun to play with :-)

**Before:**
<img width="598" alt="Skärmavbild 2020-11-29 kl  18 46 05" src="https://user-images.githubusercontent.com/647031/100549486-72961b80-3273-11eb-82de-fc2a0037c7b6.png">

**After:**
<img width="584" alt="Skärmavbild 2020-11-29 kl  18 58 43" src="https://user-images.githubusercontent.com/647031/100549716-f8ff2d00-3274-11eb-95c2-e13ab9bcb2ba.png">

