### PR TITLE
Fix dividing with infinity bug

### DIFF
--- a/src/Spectre.Console/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Progress/ProgressTask.cs
@@ -265,6 +265,14 @@ namespace Spectre.Console
                     return null;
                 }
 
+                // If the speed is zero, the estimate below
+                // will return infinity (since it's a double),
+                // so let's set the speed to 1 in that case.
+                if (speed == 0)
+                {
+                    speed = 1;
+                }
+
                 var estimate = (MaxValue - Value) / speed.Value;
                 return TimeSpan.FromSeconds(estimate);
             }


### PR DESCRIPTION
When calculating the remaining time for a progress task, we divide the value delta with the current speed. If the speed is zero, then the resulting double will be 'infinity' which will lead to TimeSpan.FromSeconds throwing.

This commit fixes that bug by setting the speed to 1 if it's 0 when calculating the remaining time.

Closes #169