### PR TITLE
remove pdb AllowedOutputExtensionsInPackageBuildOutputFolder

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -29,7 +29,6 @@
   <PropertyGroup Label="Source Link">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   
   <ItemGroup Label="Package References">


### PR DESCRIPTION
my understanding is that AllowedOutputExtensionsInPackageBuildOutputFolder pdb is redundant when u r using ebedded symbols?