### PR TITLE
Added canvas unit tests & fix canvas scaling bug

### DIFF
--- a/src/Spectre.Console.Tests/Unit/CanvasTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CanvasTests.cs
@@ -27,7 +27,7 @@ namespace Spectre.Console.Tests.Unit
         }
 
         [Fact]
-        public void Render_WiderThan_Terminal()
+        public void Render_Wider_Than_Terminal_Cannot_Be_Reduced_Further()
         {
             // Given
             var console = new FakeAnsiConsole(ColorSystem.Standard, width: 10);
@@ -39,8 +39,24 @@ namespace Spectre.Console.Tests.Unit
             console.Render(canvas);
 
             // Then
+            console.Output.ShouldBe(string.Empty);
+        }
+
+        [Fact]
+        public void Render_WiderThan_Terminal()
+        {
+            // Given
+            var console = new FakeAnsiConsole(ColorSystem.Standard, width: 10);
+            var canvas = new Canvas(width: 20, height: 10);
+            canvas.SetPixel(0, 0, Color.Aqua);
+            canvas.SetPixel(19, 9, Color.Grey);
+
+            // When
+            console.Render(canvas);
+
+            // Then
             var numNewlines = console.Output.Count(x => x == '\n');
-            numNewlines.ShouldBe(expected: 20);
+            numNewlines.ShouldBe(expected: 2);
         }
 
         [Fact]

--- a/src/Spectre.Console.Tests/Unit/CanvasTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CanvasTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using System.Text;
+using Shouldly;
+using Spectre.Console.Rendering;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace Spectre.Console.Tests.Unit
+{
+    public class CanvasTests
+    {
+        [Fact]
+        public void SimpleRender()
+        {
+            // Given
+            var console = new FakeAnsiConsole(ColorSystem.Standard);
+            var canvas = new Canvas(width: 2, height: 2);
+            canvas.SetPixel(0, 0, Color.Aqua);
+            canvas.SetPixel(1, 1, Color.Grey);
+
+            // When
+            console.Render(canvas);
+
+            // Then
+            console.Output.ShouldBe($"\u001b[106m  \u001b[0m  {Environment.NewLine}  \u001b[100m  \u001b[0m{Environment.NewLine}");
+        }
+
+        [Fact]
+        public void RenderWiderThanTerminal()
+        {
+            // Given
+            var console = new FakeAnsiConsole(ColorSystem.Standard, width: 10);
+            var canvas = new Canvas(width: 20, height: 2);
+            canvas.SetPixel(0, 0, Color.Aqua);
+            canvas.SetPixel(19, 1, Color.Grey);
+
+            // When
+            console.Render(canvas);
+
+            // Then
+            var numNewlines = console.Output.Count(x => x == '\n');
+            numNewlines.ShouldBe(expected: 20);
+        }
+
+        [Fact]
+        public void Simple_Measure()
+        {
+            // Given
+            var console = new FakeAnsiConsole(ColorSystem.Standard);
+            var canvas = new Canvas(width: 2, height: 2);
+            canvas.SetPixel(0, 0, Color.Aqua);
+            canvas.SetPixel(1, 1, Color.Grey);
+
+            // When
+            var measurement = ((IRenderable)canvas).Measure(new RenderContext(Encoding.Unicode, false), 80);
+
+            // Then
+            measurement.Max.ShouldBe(expected: 4);
+            measurement.Min.ShouldBe(expected: 4);
+        }
+    }
+}

--- a/src/Spectre.Console.Tests/Unit/CanvasTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CanvasTests.cs
@@ -11,7 +11,7 @@ namespace Spectre.Console.Tests.Unit
     public class CanvasTests
     {
         [Fact]
-        public void SimpleRender()
+        public void Simple_Render()
         {
             // Given
             var console = new FakeAnsiConsole(ColorSystem.Standard);
@@ -27,7 +27,7 @@ namespace Spectre.Console.Tests.Unit
         }
 
         [Fact]
-        public void RenderWiderThanTerminal()
+        public void Render_WiderThan_Terminal()
         {
             // Given
             var console = new FakeAnsiConsole(ColorSystem.Standard, width: 10);

--- a/src/Spectre.Console.Tests/Unit/CanvasTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CanvasTests.cs
@@ -51,7 +51,7 @@ namespace Spectre.Console.Tests.Unit
         }
 
         [Fact]
-        public void Render_WiderThan_Terminal()
+        public void Render_Wider_Than_Terminal()
         {
             // Given
             var console = new FakeAnsiConsole(ColorSystem.Standard, width: 10);
@@ -64,7 +64,26 @@ namespace Spectre.Console.Tests.Unit
 
             // Then
             var numNewlines = console.Output.Count(x => x == '\n');
+            // Small terminal shrinks the canvas
             numNewlines.ShouldBe(expected: 2);
+        }
+
+        [Fact]
+        public void Render_Wider_Configured_With_Max_Width()
+        {
+            // Given
+            var console = new FakeAnsiConsole(ColorSystem.Standard, width: 80);
+            var canvas = new Canvas(width: 20, height: 10) { MaxWidth = 10 };
+            canvas.SetPixel(0, 0, Color.Aqua);
+            canvas.SetPixel(19, 9, Color.Grey);
+
+            // When
+            console.Render(canvas);
+
+            // Then
+            var numNewlines = console.Output.Count(x => x == '\n');
+            // MaxWidth truncates the canvas
+            numNewlines.ShouldBe(expected: 5);
         }
 
         [Fact]

--- a/src/Spectre.Console.Tests/Unit/CanvasTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CanvasTests.cs
@@ -11,6 +11,14 @@ namespace Spectre.Console.Tests.Unit
     public class CanvasTests
     {
         [Fact]
+        public void Canvas_Must_Have_Proper_Size()
+        {
+            Should.Throw<ArgumentException>(() => new Canvas(1, 0));
+
+            Should.Throw<ArgumentException>(() => new Canvas(0, 1));
+        }
+
+        [Fact]
         public void Simple_Render()
         {
             // Given

--- a/src/Spectre.Console.Tests/Unit/CanvasTests.cs
+++ b/src/Spectre.Console.Tests/Unit/CanvasTests.cs
@@ -64,6 +64,7 @@ namespace Spectre.Console.Tests.Unit
 
             // Then
             var numNewlines = console.Output.Count(x => x == '\n');
+
             // Small terminal shrinks the canvas
             numNewlines.ShouldBe(expected: 2);
         }
@@ -82,6 +83,7 @@ namespace Spectre.Console.Tests.Unit
 
             // Then
             var numNewlines = console.Output.Count(x => x == '\n');
+
             // MaxWidth truncates the canvas
             numNewlines.ShouldBe(expected: 5);
         }

--- a/src/Spectre.Console/Widgets/Canvas.cs
+++ b/src/Spectre.Console/Widgets/Canvas.cs
@@ -44,6 +44,15 @@ namespace Spectre.Console
         /// <param name="height">The canvas height.</param>
         public Canvas(int width, int height)
         {
+            if (width < 1)
+            {
+                throw new ArgumentException("Must be > 1", nameof(width));
+            }
+            if (height < 1)
+            {
+                throw new ArgumentException("Must be > 1", nameof(height));
+            }
+
             Width = width;
             Height = height;
 

--- a/src/Spectre.Console/Widgets/Canvas.cs
+++ b/src/Spectre.Console/Widgets/Canvas.cs
@@ -48,6 +48,7 @@ namespace Spectre.Console
             {
                 throw new ArgumentException("Must be > 1", nameof(width));
             }
+
             if (height < 1)
             {
                 throw new ArgumentException("Must be > 1", nameof(height));

--- a/src/Spectre.Console/Widgets/Canvas.cs
+++ b/src/Spectre.Console/Widgets/Canvas.cs
@@ -104,6 +104,12 @@ namespace Spectre.Console
             {
                 height = (int)(height * (maxWidth / (float)(width * PixelWidth)));
                 width = maxWidth / PixelWidth;
+
+                // If it's not possible to scale the canvas sufficiently, it's too small to render.
+                if (height == 0)
+                {
+                    yield break;
+                }
             }
 
             // Need to rescale the pixel buffer?


### PR DESCRIPTION
No unit tests exist for Canvas, have added some coverage here.

~~Looks like behaviour for rendering a canvas wider than the terminal is broken.~~
Have fixed up `Canvas` to handle the case that it's scaled down too much to be displayed.