### PR TITLE
Fix console detection for Cygwin/WSL-Shell on Windows.

### DIFF
--- a/src/Spectre.Console/Internal/Ansi/AnsiDetector.cs
+++ b/src/Spectre.Console/Internal/Ansi/AnsiDetector.cs
@@ -65,7 +65,6 @@ namespace Spectre.Console.Internal
             {
                 if (_regexes.Any(regex => regex.IsMatch(term)))
                 {
-                    System.Console.WriteLine("TERM matches");
                     return (true, false);
                 }
             }


### PR DESCRIPTION
Currently detection on Windows checks:
 - Conemu
 - GetConsoleMode

However if you're running any other terminal emulator with the `TERM` env var set that isn't Conemu and GetConsoleMode fails for, then you're always going to get ANSI reported as not supported, when it in fact might be. This change changes the process on Windows to:
 - Conemu
 - GetConsoleMode
 - Check `TERM`

Behaviour when `TERM` is not set will not be changed. In my case I have a terminal on Windows where:
```
$ echo $TERM
xterm-256color
```
This change permits this (ANSI supporting) console to be reported correctly, and doesn't change existing behaviour when `TERM` is not set. Having checked on my mahcine: `TERM` is not set by default in powershell or cmd shells.