### PR TITLE
enables returning a result from StartAsync

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/Progress.cs
+++ b/src/Spectre.Console/Widgets/Progress/Progress.cs
@@ -80,34 +80,11 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(action));
             }
 
-            var renderer = CreateRenderer();
-            renderer.Started();
-
-            try
+            _ = await StartAsync<object?>(async progressContext =>
             {
-                using (new RenderHookScope(_console, renderer))
-                {
-                    var context = new ProgressContext(_console, renderer);
-
-                    if (AutoRefresh)
-                    {
-                        using (var thread = new ProgressRefreshThread(context, renderer.RefreshRate))
-                        {
-                            await action(context).ConfigureAwait(false);
-                        }
-                    }
-                    else
-                    {
-                        await action(context).ConfigureAwait(false);
-                    }
-
-                    context.Refresh();
-                }
-            }
-            finally
-            {
-                renderer.Completed(AutoClear);
-            }
+                await action(progressContext);
+                return default;
+            });
         }
 
         /// <summary>

--- a/src/Spectre.Console/Widgets/Progress/Status.cs
+++ b/src/Spectre.Console/Widgets/Progress/Status.cs
@@ -60,30 +60,16 @@ namespace Spectre.Console
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task StartAsync(string status, Func<StatusContext, Task> action)
         {
-            // Set the progress columns
-            var spinnerColumn = new SpinnerColumn(Spinner ?? Spinner.Known.Default)
+            if (action is null)
             {
-                Style = SpinnerStyle ?? Style.Plain,
-            };
+                throw new ArgumentNullException(nameof(action));
+            }
 
-            var progress = new Progress(_console)
+            _ = await StartAsync<object?>(status, async statusContext =>
             {
-                FallbackRenderer = new StatusFallbackRenderer(),
-                AutoClear = true,
-                AutoRefresh = AutoRefresh,
-            };
-
-            progress.Columns(new ProgressColumn[]
-            {
-                spinnerColumn,
-                new TaskDescriptionColumn(),
+                await action(statusContext);
+                return default;
             });
-
-            await progress.StartAsync(async ctx =>
-            {
-                var statusContext = new StatusContext(ctx, ctx.AddTask(status), spinnerColumn);
-                await action(statusContext).ConfigureAwait(false);
-            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -95,6 +81,11 @@ namespace Spectre.Console
         /// <returns>A <see cref="Task{T}"/> representing the asynchronous operation.</returns>
         public async Task<T> StartAsync<T>(string status, Func<StatusContext, Task<T>> action)
         {
+            if (action is null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+
             // Set the progress columns
             var spinnerColumn = new SpinnerColumn(Spinner ?? Spinner.Known.Default)
             {


### PR DESCRIPTION
This PR adds overloads to `StartAsync` which accept delegates returning a generic `Task<T>`.

E.g. this allows to show a spinner while fetching data:

```csharp
var data = AnsiConsole.Status()
    .Spinner(Spinner.Known.Star)
    .StartAsync("Fetching data...", async ctx => {
        var r = await _client.FetchDataAsync();
        return r;
    });
```

The code is mainly a copy of the existing functions but returning a generic `Task<T>`.