### PR TITLE
mask default value when prompt is a secret

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Widgets/Prompt/SecretDefaultValue.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Widgets/Prompt/SecretDefaultValue.Output.verified.txt
@@ -1,0 +1,1 @@
+Favorite fruit? (******): ******

--- a/src/Spectre.Console.Tests/Unit/PromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/PromptTests.cs
@@ -200,5 +200,23 @@ namespace Spectre.Console.Tests.Unit
             result.Item1.ShouldBe(2);
             return Verifier.Verify(console.Output);
         }
+
+        [Fact]
+        [Expectation("SecretDefaultValue")]
+        public Task Should_Chose_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret()
+        {
+            // Given
+            var console = new FakeConsole();
+            console.Input.PushKey(ConsoleKey.Enter);
+
+            // When
+            console.Prompt(
+                new TextPrompt<string>("Favorite fruit?")
+                    .Secret()
+                    .DefaultValue("Banana"));
+
+            // Then
+            return Verifier.Verify(console.Output);
+        }
     }
 }

--- a/src/Spectre.Console/Widgets/Prompt/TextPrompt.cs
+++ b/src/Spectre.Console/Widgets/Prompt/TextPrompt.cs
@@ -117,7 +117,7 @@ namespace Spectre.Console
                 {
                     if (DefaultValue != null)
                     {
-                        console.Write(converter(DefaultValue.Value), promptStyle);
+                        console.Write(IsSecret ? "******" : converter(DefaultValue.Value), promptStyle);
                         console.WriteLine();
                         return DefaultValue.Value;
                     }
@@ -186,10 +186,11 @@ namespace Spectre.Console
 
             if (ShowDefaultValue && DefaultValue != null)
             {
+                var converter = Converter ?? TypeConverterHelper.ConvertToString;
                 builder.AppendFormat(
                     CultureInfo.InvariantCulture,
                     " [green]({0})[/]",
-                    TypeConverterHelper.ConvertToString(DefaultValue.Value));
+                    IsSecret ? "******" : converter(DefaultValue.Value));
             }
 
             var markup = builder.ToString().Trim();


### PR DESCRIPTION
Currently the default value is displayed even if the text prompt is a secret. This PR will mask it with `******`.

(First I displayed the same number of `*` as the length of the default value; however, to prevent exposing the length of the default value, I replaced it with a fixed length of 6)