### PR TITLE
Customize SelectionPrompt selected choice color

### DIFF
--- a/src/Spectre.Console/Widgets/Prompt/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Widgets/Prompt/MultiSelectionPrompt.cs
@@ -36,6 +36,11 @@ namespace Spectre.Console
         public int PageSize { get; set; } = 10;
 
         /// <summary>
+        /// Gets or sets the highlight color of the selected choice.
+        /// </summary>
+        public Color? HighlightColor { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not
         /// at least one selection is required.
         /// </summary>
@@ -68,7 +73,7 @@ namespace Spectre.Console
 
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
 
-            var list = new RenderableMultiSelectionList<T>(console, Title, PageSize, Choices, converter);
+            var list = new RenderableMultiSelectionList<T>(console, Title, PageSize, Choices, converter, HighlightColor);
             using (new RenderHookScope(console, list))
             {
                 console.Cursor.Hide();

--- a/src/Spectre.Console/Widgets/Prompt/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Widgets/Prompt/MultiSelectionPrompt.cs
@@ -36,9 +36,9 @@ namespace Spectre.Console
         public int PageSize { get; set; } = 10;
 
         /// <summary>
-        /// Gets or sets the highlight color of the selected choice.
+        /// Gets or sets the highlight style of the selected choice.
         /// </summary>
-        public Color? HighlightColor { get; set; }
+        public Style? HighlightStyle { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not
@@ -73,7 +73,7 @@ namespace Spectre.Console
 
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
 
-            var list = new RenderableMultiSelectionList<T>(console, Title, PageSize, Choices, converter, HighlightColor);
+            var list = new RenderableMultiSelectionList<T>(console, Title, PageSize, Choices, converter, HighlightStyle);
             using (new RenderHookScope(console, list))
             {
                 console.Cursor.Hide();

--- a/src/Spectre.Console/Widgets/Prompt/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/MultiSelectionPromptExtensions.cs
@@ -104,6 +104,24 @@ namespace Spectre.Console
         }
 
         /// <summary>
+        /// Sets the highlight color of the selected choice.
+        /// </summary>
+        /// <typeparam name="T">The prompt result type.</typeparam>
+        /// <param name="obj">The prompt.</param>
+        /// <param name="highlightColor">The highlight color of the selected choice.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static MultiSelectionPrompt<T> HighlightColor<T>(this MultiSelectionPrompt<T> obj, Color highlightColor)
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.HighlightColor = highlightColor;
+            return obj;
+        }
+
+        /// <summary>
         /// Requires no choice to be selected.
         /// </summary>
         /// <typeparam name="T">The prompt result type.</typeparam>

--- a/src/Spectre.Console/Widgets/Prompt/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/MultiSelectionPromptExtensions.cs
@@ -108,16 +108,16 @@ namespace Spectre.Console
         /// </summary>
         /// <typeparam name="T">The prompt result type.</typeparam>
         /// <param name="obj">The prompt.</param>
-        /// <param name="highlightColor">The highlight color of the selected choice.</param>
+        /// <param name="highlightStyle">The highlight style of the selected choice.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static MultiSelectionPrompt<T> HighlightColor<T>(this MultiSelectionPrompt<T> obj, Color highlightColor)
+        public static MultiSelectionPrompt<T> HighlightStyle<T>(this MultiSelectionPrompt<T> obj, Style highlightStyle)
         {
             if (obj is null)
             {
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            obj.HighlightColor = highlightColor;
+            obj.HighlightStyle = highlightStyle;
             return obj;
         }
 

--- a/src/Spectre.Console/Widgets/Prompt/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/MultiSelectionPromptExtensions.cs
@@ -104,7 +104,7 @@ namespace Spectre.Console
         }
 
         /// <summary>
-        /// Sets the highlight color of the selected choice.
+        /// Sets the highlight style of the selected choice.
         /// </summary>
         /// <typeparam name="T">The prompt result type.</typeparam>
         /// <param name="obj">The prompt.</param>

--- a/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableMultiSelectionList.cs
+++ b/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableMultiSelectionList.cs
@@ -17,12 +17,12 @@ namespace Spectre.Console
 
         public RenderableMultiSelectionList(
             IAnsiConsole console, string? title, int pageSize,
-            List<T> choices, Func<T, string>? converter, Color? highlightColor)
+            List<T> choices, Func<T, string>? converter, Style? highlightStyle)
             : base(console, pageSize, choices, converter)
         {
             _console = console ?? throw new ArgumentNullException(nameof(console));
             _title = title;
-            _highlightStyle = new Style(foreground: highlightColor ?? Color.Blue);
+            _highlightStyle = highlightStyle ?? new Style(foreground: Color.Blue);
 
             Selections = new HashSet<int>();
         }

--- a/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableMultiSelectionList.cs
+++ b/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableMultiSelectionList.cs
@@ -17,12 +17,12 @@ namespace Spectre.Console
 
         public RenderableMultiSelectionList(
             IAnsiConsole console, string? title, int pageSize,
-            List<T> choices, Func<T, string>? converter)
+            List<T> choices, Func<T, string>? converter, Color? highlightColor)
             : base(console, pageSize, choices, converter)
         {
             _console = console ?? throw new ArgumentNullException(nameof(console));
             _title = title;
-            _highlightStyle = new Style(foreground: Color.Blue);
+            _highlightStyle = new Style(foreground: highlightColor ?? Color.Blue);
 
             Selections = new HashSet<int>();
         }

--- a/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableSelectionList.cs
+++ b/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableSelectionList.cs
@@ -12,12 +12,12 @@ namespace Spectre.Console
         private readonly string? _title;
         private readonly Style _highlightStyle;
 
-        public RenderableSelectionList(IAnsiConsole console, string? title, int requestedPageSize, List<T> choices, Func<T, string>? converter, Color? highlightColor)
+        public RenderableSelectionList(IAnsiConsole console, string? title, int requestedPageSize, List<T> choices, Func<T, string>? converter, Style? highlightStyle)
             : base(console, requestedPageSize, choices, converter)
         {
             _console = console ?? throw new ArgumentNullException(nameof(console));
             _title = title;
-            _highlightStyle = new Style(foreground: highlightColor ?? Color.Blue);
+            _highlightStyle = highlightStyle ?? new Style(foreground: Color.Blue);
         }
 
         protected override int CalculatePageSize(int requestedPageSize)

--- a/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableSelectionList.cs
+++ b/src/Spectre.Console/Widgets/Prompt/Rendering/RenderableSelectionList.cs
@@ -12,12 +12,12 @@ namespace Spectre.Console
         private readonly string? _title;
         private readonly Style _highlightStyle;
 
-        public RenderableSelectionList(IAnsiConsole console, string? title, int requestedPageSize, List<T> choices, Func<T, string>? converter)
+        public RenderableSelectionList(IAnsiConsole console, string? title, int requestedPageSize, List<T> choices, Func<T, string>? converter, Color? highlightColor)
             : base(console, requestedPageSize, choices, converter)
         {
             _console = console ?? throw new ArgumentNullException(nameof(console));
             _title = title;
-            _highlightStyle = new Style(foreground: Color.Blue);
+            _highlightStyle = new Style(foreground: highlightColor ?? Color.Blue);
         }
 
         protected override int CalculatePageSize(int requestedPageSize)

--- a/src/Spectre.Console/Widgets/Prompt/SelectionPrompt.cs
+++ b/src/Spectre.Console/Widgets/Prompt/SelectionPrompt.cs
@@ -35,6 +35,11 @@ namespace Spectre.Console
         public int PageSize { get; set; } = 10;
 
         /// <summary>
+        /// Gets or sets the highlight color of the selected choice.
+        /// </summary>
+        public Color? HighlightColor { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.
         /// </summary>
         public SelectionPrompt()
@@ -61,7 +66,7 @@ namespace Spectre.Console
 
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
 
-            var list = new RenderableSelectionList<T>(console, Title, PageSize, Choices, converter);
+            var list = new RenderableSelectionList<T>(console, Title, PageSize, Choices, converter, HighlightColor);
             using (new RenderHookScope(console, list))
             {
                 console.Cursor.Hide();

--- a/src/Spectre.Console/Widgets/Prompt/SelectionPrompt.cs
+++ b/src/Spectre.Console/Widgets/Prompt/SelectionPrompt.cs
@@ -35,9 +35,9 @@ namespace Spectre.Console
         public int PageSize { get; set; } = 10;
 
         /// <summary>
-        /// Gets or sets the highlight color of the selected choice.
+        /// Gets or sets the highlight style of the selected choice.
         /// </summary>
-        public Color? HighlightColor { get; set; }
+        public Style? HighlightStyle { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.
@@ -66,7 +66,7 @@ namespace Spectre.Console
 
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
 
-            var list = new RenderableSelectionList<T>(console, Title, PageSize, Choices, converter, HighlightColor);
+            var list = new RenderableSelectionList<T>(console, Title, PageSize, Choices, converter, HighlightStyle);
             using (new RenderHookScope(console, list))
             {
                 console.Cursor.Hide();

--- a/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
@@ -108,16 +108,16 @@ namespace Spectre.Console
         /// </summary>
         /// <typeparam name="T">The prompt result type.</typeparam>
         /// <param name="obj">The prompt.</param>
-        /// <param name="highlightColor">The highlight color of the selected choice.</param>
+        /// <param name="highlightStyle">The highlight style of the selected choice.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static SelectionPrompt<T> HighlightColor<T>(this SelectionPrompt<T> obj, Color highlightColor)
+        public static SelectionPrompt<T> HighlightStyle<T>(this SelectionPrompt<T> obj, Style highlightStyle)
         {
             if (obj is null)
             {
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            obj.HighlightColor = highlightColor;
+            obj.HighlightStyle = highlightStyle;
             return obj;
         }
 

--- a/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
@@ -108,7 +108,7 @@ namespace Spectre.Console
         /// </summary>
         /// <typeparam name="T">The prompt result type.</typeparam>
         /// <param name="obj">The prompt.</param>
-        /// <param name="highlightColor">The highlight color of the selected choice</param>
+        /// <param name="highlightColor">The highlight color of the selected choice.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public static SelectionPrompt<T> HighlightColor<T>(this SelectionPrompt<T> obj, Color highlightColor)
         {

--- a/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
@@ -104,6 +104,24 @@ namespace Spectre.Console
         }
 
         /// <summary>
+        /// Sets the highlight color of the selected choice.
+        /// </summary>
+        /// <typeparam name="T">The prompt result type.</typeparam>
+        /// <param name="obj">The prompt.</param>
+        /// <param name="highlightColor">The highlight color of the selected choice</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static SelectionPrompt<T> HighlightColor<T>(this SelectionPrompt<T> obj, Color highlightColor)
+        {
+            if (obj is null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            obj.HighlightColor = highlightColor;
+            return obj;
+        }
+
+        /// <summary>
         /// Sets the function to create a display string for a given choice.
         /// </summary>
         /// <typeparam name="T">The prompt type.</typeparam>

--- a/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Widgets/Prompt/SelectionPromptExtensions.cs
@@ -104,7 +104,7 @@ namespace Spectre.Console
         }
 
         /// <summary>
-        /// Sets the highlight color of the selected choice.
+        /// Sets the highlight style of the selected choice.
         /// </summary>
         /// <typeparam name="T">The prompt result type.</typeparam>
         /// <param name="obj">The prompt.</param>


### PR DESCRIPTION
Currently the highlight color for the selected choice in SelectionPrompt and MultiSelectionPrompt is always blue and can result in visibility problems on black backgrounds:
![image](https://user-images.githubusercontent.com/46056725/104596340-c74af580-566b-11eb-84ca-fb791e394ef2.png)

Can now be changed by using `.HighlightColor(Color.Red)` for example making it easier to see and more customizable:

![image](https://user-images.githubusercontent.com/46056725/104596761-52c48680-566c-11eb-990a-f2a76110a583.png)

Example in context:
```cs
fruit = AnsiConsole.Prompt(
        new SelectionPrompt<string>()
            .Title("Ok, but if you could only choose [green]one[/]?")
            .AddChoices(favorites)
            .HighlightColor(Color.Red));
```
 