### PR TITLE
SetApplicatiionVersion / better was to auto-detect application version

### DIFF
--- a/examples/Cli/Demo/Demo.csproj
+++ b/examples/Cli/Demo/Demo.csproj
@@ -8,6 +8,7 @@
     <ExampleDescription>Demonstrates the most common use cases of Spectre.Cli.</ExampleDescription>
     <ExampleGroup>Cli</ExampleGroup>
     <ExampleVisible>false</ExampleVisible>
+    <Version>1.2.3.4-beta.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/Cli/Demo/Program.cs
+++ b/examples/Cli/Demo/Program.cs
@@ -11,6 +11,7 @@ namespace Demo
             app.Configure(config =>
             {
                 config.SetApplicationName("fake-dotnet");
+                // config.SetApplicationVersion("1.3.3.7-ultra!");
                 config.ValidateExamples();
                 config.AddExample(new[] { "run", "--no-build" });
 

--- a/src/Spectre.Console/Cli/CommandApp.cs
+++ b/src/Spectre.Console/Cli/CommandApp.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Spectre.Console.Rendering;
 
@@ -84,7 +85,7 @@ namespace Spectre.Console.Cli
                 }
 
                 return await _executor
-                    .Execute(_configurator, args)
+                    .Execute(_configurator, args.ToArray())
                     .ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/src/Spectre.Console/Cli/ConfiguratorExtensions.cs
+++ b/src/Spectre.Console/Cli/ConfiguratorExtensions.cs
@@ -26,6 +26,23 @@ namespace Spectre.Console.Cli
         }
 
         /// <summary>
+        /// Overrides the auto-detected version of the application.
+        /// </summary>
+        /// <param name="configurator">The configurator.</param>
+        /// <param name="version">The version of application.</param>
+        /// <returns>A configurator that can be used to configure the application further.</returns>
+        public static IConfigurator SetApplicationVersion(this IConfigurator configurator, string version)
+        {
+            if (configurator == null)
+            {
+                throw new ArgumentNullException(nameof(configurator));
+            }
+
+            configurator.Settings.ApplicationVersion = version;
+            return configurator;
+        }
+
+        /// <summary>
         /// Configures the console.
         /// </summary>
         /// <param name="configurator">The configurator.</param>

--- a/src/Spectre.Console/Cli/ICommandAppSettings.cs
+++ b/src/Spectre.Console/Cli/ICommandAppSettings.cs
@@ -11,6 +11,11 @@ namespace Spectre.Console.Cli
         string? ApplicationName { get; set; }
 
         /// <summary>
+        /// Gets or sets the application version (use it to override auto-detected value).
+        /// </summary>
+        string? ApplicationVersion { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="IAnsiConsole"/>.
         /// </summary>
         IAnsiConsole? Console { get; set; }

--- a/src/Spectre.Console/Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console/Cli/Internal/CommandExecutor.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Spectre.Console.Cli
@@ -16,7 +15,7 @@ namespace Spectre.Console.Cli
             _registrar.Register(typeof(DefaultPairDeconstructor), typeof(DefaultPairDeconstructor));
         }
 
-        public Task<int> Execute(IConfiguration configuration, IEnumerable<string> args)
+        public Task<int> Execute(IConfiguration configuration, IReadOnlyCollection<string> args)
         {
             if (configuration == null)
             {
@@ -44,7 +43,7 @@ namespace Spectre.Console.Cli
                         firstArgument.Equals("-v", StringComparison.OrdinalIgnoreCase))
                     {
                         var console = configuration.Settings.Console.GetConsole();
-                        console.WriteLine(VersionHelper.GetVersion(Assembly.GetEntryAssembly()));
+                        console.WriteLine(ResolveApplicationVersion(configuration));
                         return Task.FromResult(0);
                     }
                 }
@@ -82,6 +81,10 @@ namespace Spectre.Console.Cli
             // Execute the command tree.
             return Execute(leaf, parsedResult.Tree, context, resolver, configuration);
         }
+
+        private static string ResolveApplicationVersion(IConfiguration configuration) =>
+            configuration.Settings.ApplicationVersion ?? // potential override
+            VersionHelper.GetApplicationVersion();
 
         private static Task<int> Execute(
             CommandTree leaf,

--- a/src/Spectre.Console/Cli/Internal/Configuration/CommandAppSettings.cs
+++ b/src/Spectre.Console/Cli/Internal/Configuration/CommandAppSettings.cs
@@ -5,6 +5,7 @@ namespace Spectre.Console.Cli
     internal sealed class CommandAppSettings : ICommandAppSettings
     {
         public string? ApplicationName { get; set; }
+        public string? ApplicationVersion { get; set; }
         public IAnsiConsole? Console { get; set; }
         public ICommandInterceptor? Interceptor { get; set; }
         public ITypeRegistrarFrontend Registrar { get; set; }

--- a/src/Spectre.Console/Cli/Internal/Modelling/CommandModel.cs
+++ b/src/Spectre.Console/Cli/Internal/Modelling/CommandModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 
@@ -26,9 +27,16 @@ namespace Spectre.Console.Cli
             Examples = new List<string[]>(examples ?? Array.Empty<string[]>());
         }
 
-        public string GetApplicationName()
-        {
-            return ApplicationName ?? Path.GetFileName(Assembly.GetEntryAssembly()?.Location) ?? "?";
-        }
+        public string GetApplicationName() =>
+            ApplicationName ??
+            Path.GetFileName(GetApplicationFile()) ?? // it is actually null safe
+            "?";
+
+        private static string? GetApplicationFile() =>
+            Assembly.GetEntryAssembly()?.Location switch // location can be empty string or null
+            {
+                var location when !string.IsNullOrWhiteSpace(location) => location,
+                _ => Process.GetCurrentProcess().MainModule?.FileName,
+            };
     }
 }

--- a/src/Spectre.Console/Cli/Internal/VersionHelper.cs
+++ b/src/Spectre.Console/Cli/Internal/VersionHelper.cs
@@ -5,22 +5,20 @@ namespace Spectre.Console.Cli
 {
     internal static class VersionHelper
     {
-        public static string GetVersion(Assembly? assembly)
-        {
-            if (assembly == null)
-            {
-                return "?";
-            }
+        private static string? TryGetAssemblyVersion(Assembly? assembly) =>
+            assembly?
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
 
-            try
-            {
-                var info = FileVersionInfo.GetVersionInfo(assembly.Location);
-                return info.ProductVersion ?? assembly?.GetName()?.Version?.ToString() ?? "?";
-            }
-            catch
-            {
-                return "?";
-            }
-        }
+        private static FileVersionInfo? TryGetMainModuleVersionInfo() =>
+            Process.GetCurrentProcess().MainModule?.FileVersionInfo;
+
+        public static string GetVersion(Assembly? assembly) =>
+            TryGetAssemblyVersion(assembly) ?? "?";
+
+        public static string GetApplicationVersion() =>
+            TryGetAssemblyVersion(Assembly.GetEntryAssembly()) ??
+            TryGetMainModuleVersionInfo()?.ProductVersion ??
+            "?";
     }
 }


### PR DESCRIPTION
* added SetApplicationVersion(...) to configurator, so version can be overridden (but doesn't have to)
* changed VersionHelper to retrieve assembly version in a way compatible with single file executable
* modified "Demo" application to actually have a version included in csproj and/or configured from Program.cs
* ApplicationName was also falling back to Assembly.Location which does not work in single file executable