### PR TITLE
Implemented buffer/stream constructors for CanvasImage

### DIFF
--- a/examples/Console/Canvas/Canvas.csproj
+++ b/examples/Console/Canvas/Canvas.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="cake.png">
+    <EmbeddedResource Include="cake.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/examples/Console/Canvas/Program.cs
+++ b/examples/Console/Canvas/Program.cs
@@ -26,7 +26,7 @@ namespace CanvasExample
             image.Mutate(ctx => ctx.Grayscale().Rotate(-45).EntropyCrop());
             Render(image, "Image from file (fit, greyscale, rotated)");
 
-            //Draw image again, but load from embedded resource rather than file
+            // Draw image again, but load from embedded resource rather than file
             using (var fileStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Canvas.cake.png"))
             {
                 Debug.Assert(fileStream != null);

--- a/examples/Console/Canvas/Program.cs
+++ b/examples/Console/Canvas/Program.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Reflection;
 using SixLabors.ImageSharp.Processing;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -23,6 +25,16 @@ namespace CanvasExample
             image.NoMaxWidth();
             image.Mutate(ctx => ctx.Grayscale().Rotate(-45).EntropyCrop());
             Render(image, "Image from file (fit, greyscale, rotated)");
+
+            //Draw image again, but load from embedded resource rather than file
+            using (var fileStream = Assembly.GetExecutingAssembly().GetManifestResourceStream("Canvas.cake.png"))
+            {
+                Debug.Assert(fileStream != null);
+                var embeddedImage = new CanvasImage(fileStream);
+                embeddedImage.BilinearResampler();
+                embeddedImage.MaxWidth(16);
+                Render(embeddedImage, "Image from embedded resource (16 wide)");
+            }
         }
 
         private static void Render(IRenderable canvas, string title)

--- a/src/Spectre.Console.ImageSharp/CanvasImage.cs
+++ b/src/Spectre.Console.ImageSharp/CanvasImage.cs
@@ -55,7 +55,7 @@ namespace Spectre.Console
         /// <summary>
         /// Initializes a new instance of the <see cref="CanvasImage"/> class.
         /// </summary>
-        /// <param name="data">Buffer containing an image</param>
+        /// <param name="data">Buffer containing an image.</param>
         public CanvasImage(ReadOnlySpan<byte> data)
         {
             Image = SixLabors.ImageSharp.Image.Load<Rgba32>(data);
@@ -64,7 +64,7 @@ namespace Spectre.Console
         /// <summary>
         /// Initializes a new instance of the <see cref="CanvasImage"/> class.
         /// </summary>
-        /// <param name="data">Stream containing an image</param>
+        /// <param name="data">Stream containing an image.</param>
         public CanvasImage(Stream data)
         {
             Image = SixLabors.ImageSharp.Image.Load<Rgba32>(data);

--- a/src/Spectre.Console.ImageSharp/CanvasImage.cs
+++ b/src/Spectre.Console.ImageSharp/CanvasImage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Transforms;
@@ -49,6 +50,24 @@ namespace Spectre.Console
         public CanvasImage(string filename)
         {
             Image = SixLabors.ImageSharp.Image.Load<Rgba32>(filename);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasImage"/> class.
+        /// </summary>
+        /// <param name="data">Buffer containing an image</param>
+        public CanvasImage(ReadOnlySpan<byte> data)
+        {
+            Image = SixLabors.ImageSharp.Image.Load<Rgba32>(data);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CanvasImage"/> class.
+        /// </summary>
+        /// <param name="data">Stream containing an image</param>
+        public CanvasImage(Stream data)
+        {
+            Image = SixLabors.ImageSharp.Image.Load<Rgba32>(data);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Implemented feature to allow CanvasImage construction from an in memory buffer/stream. Added demonstration code to Canvas example.

As discussed [here](https://github.com/spectresystems/spectre.console/discussions/243)