### PR TITLE
Treat stderr as equivalent to stdout

### DIFF
--- a/src/Spectre.Console/AnsiConsoleFactory.cs
+++ b/src/Spectre.Console/AnsiConsoleFactory.cs
@@ -28,7 +28,7 @@ namespace Spectre.Console
             var (supportsAnsi, legacyConsole) = DetectAnsi(settings, buffer);
 
             // Use the provided encoding or fall back to UTF-8
-            var encoding = buffer.IsStandardOut() ? System.Console.OutputEncoding : Encoding.UTF8;
+            var encoding = buffer.IsStandardOut() || buffer.IsStandardError() ? System.Console.OutputEncoding : Encoding.UTF8;
 
             // Get the color system
             var colorSystem = settings.ColorSystem == ColorSystemSupport.Detect
@@ -73,14 +73,14 @@ namespace Spectre.Console
                 // Check whether or not this is a legacy console from the existing instance (if any).
                 // We need to do this because once we upgrade the console to support ENABLE_VIRTUAL_TERMINAL_PROCESSING
                 // on Windows, there is no way of detecting whether or not we're running on a legacy console or not.
-                if (AnsiConsole.Created && !legacyConsole && buffer.IsStandardOut() && AnsiConsole.Profile.Capabilities.Legacy)
+                if (AnsiConsole.Created && !legacyConsole && (buffer.IsStandardOut() || buffer.IsStandardError()) && AnsiConsole.Profile.Capabilities.Legacy)
                 {
                     legacyConsole = AnsiConsole.Profile.Capabilities.Legacy;
                 }
             }
             else
             {
-                if (buffer.IsStandardOut())
+                if (buffer.IsStandardOut() || buffer.IsStandardError())
                 {
                     // Are we running on Windows?
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/Spectre.Console/Capabilities.cs
+++ b/src/Spectre.Console/Capabilities.cs
@@ -49,6 +49,11 @@ namespace Spectre.Console
                     return System.Console.IsOutputRedirected;
                 }
 
+                if (_profile.Out.IsStandardError())
+                {
+                    return System.Console.IsErrorRedirected;
+                }
+
                 // Not stdout, so must be a TTY.
                 return true;
             }

--- a/src/Spectre.Console/Extensions/TextWriterExtensions.cs
+++ b/src/Spectre.Console/Extensions/TextWriterExtensions.cs
@@ -15,5 +15,17 @@ namespace Spectre.Console
                 return false;
             }
         }
+
+        public static bool IsStandardError(this TextWriter writer)
+        {
+            try
+            {
+                return writer == System.Console.Error;
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Spectre.Console/Profile.cs
+++ b/src/Spectre.Console/Profile.cs
@@ -73,7 +73,7 @@ namespace Spectre.Console
                 }
 
                 // Need to update the output encoding for stdout?
-                if (_out.IsStandardOut())
+                if (_out.IsStandardOut() || _out.IsStandardError())
                 {
                     System.Console.OutputEncoding = value;
                 }


### PR DESCRIPTION
I would like to use Spectre.Console to write certain output like progress bars to stderr so that it remains visible even when stdout is redirected. I hoped to achieve this with:

```
var stderrConsole = AnsiConsole.Create(new AnsiConsoleSettings {Out = Console.Error});
```

However the ANSI control characters don't seem to work on stderr. I think this may be because of checks like these:

https://github.com/spectresystems/spectre.console/blob/e20f6284f962d53eab725285c76303dac768f62a/src/Spectre.Console/AnsiConsoleFactory.cs#L30-L31

I'm hoping that the change in this PR will cause both stdout and stderr to be treated as "normal" non-redirected console output.