### PR TITLE
Register the console lazily in CLI type registrar

### DIFF
--- a/examples/Cli/Injection/Infrastructure/TypeRegistrar.cs
+++ b/examples/Cli/Injection/Infrastructure/TypeRegistrar.cs
@@ -27,5 +27,15 @@ namespace Injection
         {
             _builder.AddSingleton(service, implementation);
         }
+
+        public void RegisterLazy(Type service, Func<object> func)
+        {
+            if (func is null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
+            _builder.AddSingleton(service, (provider) => func());
+        }
     }
 }

--- a/src/Spectre.Console.Testing/Fakes/FakeTypeRegistrar.cs
+++ b/src/Spectre.Console.Testing/Fakes/FakeTypeRegistrar.cs
@@ -37,6 +37,19 @@ namespace Spectre.Console.Testing
             }
         }
 
+        public void RegisterLazy(Type service, Func<object> factory)
+        {
+            if (factory is null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (!Instances.ContainsKey(service))
+            {
+                Instances.Add(service, new List<object> { factory() });
+            }
+        }
+
         public ITypeResolver Build()
         {
             return _resolver;

--- a/src/Spectre.Console/Cli/ITypeRegistrar.cs
+++ b/src/Spectre.Console/Cli/ITypeRegistrar.cs
@@ -22,6 +22,13 @@ namespace Spectre.Console.Cli
         void RegisterInstance(Type service, object implementation);
 
         /// <summary>
+        /// Registers the specified instance lazily.
+        /// </summary>
+        /// <param name="service">The service.</param>
+        /// <param name="factory">The factory that creates the implementation.</param>
+        void RegisterLazy(Type service, Func<object> factory);
+
+        /// <summary>
         /// Builds the type resolver representing the registrations
         /// specified in the current instance.
         /// </summary>

--- a/src/Spectre.Console/Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console/Cli/Internal/CommandExecutor.cs
@@ -24,7 +24,7 @@ namespace Spectre.Console.Cli
             }
 
             _registrar.RegisterInstance(typeof(IConfiguration), configuration);
-            _registrar.RegisterInstance(typeof(IAnsiConsole), configuration.Settings.Console.GetConsole());
+            _registrar.RegisterLazy(typeof(IAnsiConsole), () => configuration.Settings.Console.GetConsole());
 
             // Create the command model.
             var model = CommandModelBuilder.Build(configuration);

--- a/src/Spectre.Console/Cli/Internal/Composition/DefaultTypeRegistrar.cs
+++ b/src/Spectre.Console/Cli/Internal/Composition/DefaultTypeRegistrar.cs
@@ -35,5 +35,21 @@ namespace Spectre.Console.Cli
             var registration = new ComponentRegistration(service, new CachingActivator(new InstanceActivator(implementation)));
             _registry.Enqueue(registry => registry.Register(registration));
         }
+
+        public void RegisterLazy(Type service, Func<object> factory)
+        {
+            if (factory is null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            _registry.Enqueue(registry =>
+            {
+                var activator = new CachingActivator(new InstanceActivator(factory()));
+                var registration = new ComponentRegistration(service, activator);
+
+                registry.Register(registration);
+            });
+        }
     }
 }


### PR DESCRIPTION
This should fix a strange bug we're seeing in Cake on macOS.