### PR TITLE
Adds text and Progress bar spinner column for tasks yet to be started

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/Columns/SpinnerColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/SpinnerColumn.cs
@@ -53,7 +53,7 @@ namespace Spectre.Console
 
         /// <summary>
         /// Gets or sets the text that should be shown instead
-        /// of the spinner once a task completes.
+        /// of the spinner before a task begins.
         /// </summary>
         public string? PendingText
         {
@@ -71,7 +71,7 @@ namespace Spectre.Console
         public Style? CompletedStyle { get; set; }
 
         /// <summary>
-        /// Gets or sets the completed style.
+        /// Gets or sets the pending style.
         /// </summary>
         public Style? PendingStyle { get; set; }
 

--- a/src/Spectre.Console/Widgets/Progress/Columns/SpinnerColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/SpinnerColumn.cs
@@ -16,6 +16,7 @@ namespace Spectre.Console
         private Spinner _spinner;
         private int? _maxWidth;
         private string? _completed;
+        private string? _pending;
 
         /// <inheritdoc/>
         protected internal override bool NoWrap => true;
@@ -51,9 +52,28 @@ namespace Spectre.Console
         }
 
         /// <summary>
+        /// Gets or sets the text that should be shown instead
+        /// of the spinner once a task completes.
+        /// </summary>
+        public string? PendingText
+        {
+            get => _pending;
+            set
+            {
+                _pending = value;
+                _maxWidth = null;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the completed style.
         /// </summary>
         public Style? CompletedStyle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the completed style.
+        /// </summary>
+        public Style? PendingStyle { get; set; }
 
         /// <summary>
         /// Gets or sets the style of the spinner.
@@ -84,7 +104,12 @@ namespace Spectre.Console
             var useAscii = (context.LegacyConsole || !context.Unicode) && _spinner.IsUnicode;
             var spinner = useAscii ? Spinner.Known.Ascii : _spinner ?? Spinner.Known.Default;
 
-            if (!task.IsStarted || task.IsFinished)
+            if (!task.IsStarted)
+            {
+                return new Markup(PendingText ?? " ", PendingStyle ?? Style.Plain);
+            }
+
+            if (task.IsFinished)
             {
                 return new Markup(CompletedText ?? " ", CompletedStyle ?? Style.Plain);
             }
@@ -116,8 +141,9 @@ namespace Spectre.Console
                     var useAscii = (context.LegacyConsole || !context.Unicode) && _spinner.IsUnicode;
                     var spinner = useAscii ? Spinner.Known.Ascii : _spinner ?? Spinner.Known.Default;
 
-                    _maxWidth = Math.Max(
-                        ((IRenderable)new Markup(CompletedText ?? " ")).Measure(context, int.MaxValue).Max,
+                    _maxWidth = Math.Max(Math.Max(
+                        ((IRenderable)new Markup(PendingText ?? " ")).Measure(context, int.MaxValue).Max,
+                        ((IRenderable)new Markup(CompletedText ?? " ")).Measure(context, int.MaxValue).Max),
                         spinner.Frames.Max(frame => Cell.GetCellLength(context, frame)));
                 }
 

--- a/src/Spectre.Console/Widgets/Progress/Columns/SpinnerColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/SpinnerColumn.cs
@@ -141,7 +141,8 @@ namespace Spectre.Console
                     var useAscii = (context.LegacyConsole || !context.Unicode) && _spinner.IsUnicode;
                     var spinner = useAscii ? Spinner.Known.Ascii : _spinner ?? Spinner.Known.Default;
 
-                    _maxWidth = Math.Max(Math.Max(
+                    _maxWidth = Math.Max(
+                        Math.Max(
                         ((IRenderable)new Markup(PendingText ?? " ")).Measure(context, int.MaxValue).Max,
                         ((IRenderable)new Markup(CompletedText ?? " ")).Measure(context, int.MaxValue).Max),
                         spinner.Frames.Max(frame => Cell.GetCellLength(context, frame)));


### PR DESCRIPTION
I was running into this issue. 

![image](https://user-images.githubusercontent.com/2447331/107867605-55242700-6e4a-11eb-81fc-637275fd53d0.png)

My code is setting `CompletedText` to the check box, but then I started setting `AutoStart` to false to get better results for things like download speed and noticed the checkbox was popping up for tasks yet to be started. 

For backwards compatibility, `PendingText` should probably fall back to `CompletedText` but I suspect I'm the only one using this feature at this point so probably no need to introduce that complexity. Hopefully.