### PR TITLE
Make default answer for confirmation prompt configurable

### DIFF
--- a/src/Spectre.Console/AnsiConsole.Prompt.cs
+++ b/src/Spectre.Console/AnsiConsole.Prompt.cs
@@ -38,10 +38,15 @@ namespace Spectre.Console
         /// Displays a prompt with two choices, yes or no.
         /// </summary>
         /// <param name="prompt">The prompt markup text.</param>
+        /// <param name="defaultValue">Specifies the default answer.</param>
         /// <returns><c>true</c> if the user selected "yes", otherwise <c>false</c>.</returns>
-        public static bool Confirm(string prompt)
+        public static bool Confirm(string prompt, bool defaultValue = true)
         {
-            return new ConfirmationPrompt(prompt).Show(Console);
+            return new ConfirmationPrompt(prompt)
+            {
+                DefaultValue = defaultValue,
+            }
+            .Show(Console);
         }
     }
 }

--- a/src/Spectre.Console/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/ConfirmationPrompt.cs
@@ -18,6 +18,11 @@ namespace Spectre.Console
         public char No { get; set; } = 'n';
 
         /// <summary>
+        /// Gets or sets a value indicating whether "yes" is the default answer.
+        /// </summary>
+        public bool DefaultValue { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the message for invalid choices.
         /// </summary>
         public string InvalidChoiceMessage { get; set; } = "[red]Please select one of the available options[/]";
@@ -51,7 +56,7 @@ namespace Spectre.Console
                 .ValidationErrorMessage(InvalidChoiceMessage)
                 .ShowChoices(ShowChoices)
                 .ShowDefaultValue(ShowDefaultValue)
-                .DefaultValue(Yes)
+                .DefaultValue(DefaultValue ? Yes : No)
                 .AddChoice(Yes)
                 .AddChoice(No);
 


### PR DESCRIPTION
This PR adds an optional parameter to `AnsiConsole.Confirm` to change the default answer. IMHO it's not uncommon to default to "no", esp. when your code will do some irreversible work.