### PR TITLE
make alignment of TaskDescriptionColumn configurable

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/Columns/TaskDescriptionColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/TaskDescriptionColumn.cs
@@ -11,11 +11,16 @@ namespace Spectre.Console
         /// <inheritdoc/>
         protected internal override bool NoWrap => true;
 
+        /// <summary>
+        /// Gets or sets the alignment of the task description.
+        /// </summary>
+        public Justify Alignment { get; set; } = Justify.Right;
+
         /// <inheritdoc/>
         public override IRenderable Render(RenderContext context, ProgressTask task, TimeSpan deltaTime)
         {
             var text = task.Description?.RemoveNewLines()?.Trim();
-            return new Markup(text ?? string.Empty).Overflow(Overflow.Ellipsis).RightAligned();
+            return new Markup(text ?? string.Empty).Overflow(Overflow.Ellipsis).Alignment(Alignment);
         }
     }
 }


### PR DESCRIPTION
This PR allows to change the alignment of `TaskDescriptionColumn`.

In my application the progress is indetermined, therefore I only showing `SpinnerColumn` and `TaskDescriptionColumn`. It looks weird if the latter is right aligned :wink: