### PR TITLE
Adds DotSettings and tweaks editoconfigs for test projects

### DIFF
--- a/src/Spectre.Console.Testing/.editorconfig
+++ b/src/Spectre.Console.Testing/.editorconfig
@@ -7,6 +7,9 @@ dotnet_diagnostic.CS1591.severity = none
 # SA1600: Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
 
+# SA1200: Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = none
+
 # Default severity for analyzer diagnostics with category 'StyleCop.CSharp.OrderingRules'
 dotnet_analyzer_diagnostic.category-StyleCop.CSharp.OrderingRules.severity = none
 

--- a/src/Spectre.Console.Tests/.editorconfig
+++ b/src/Spectre.Console.Tests/.editorconfig
@@ -7,6 +7,12 @@ dotnet_analyzer_diagnostic.category-StyleCop.CSharp.DocumentationRules.severity 
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
 
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# SA1601: Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = none
+
 # SA1200: Using directives should be placed correctly
 dotnet_diagnostic.SA1200.severity = none
 

--- a/src/Spectre.Console.sln.DotSettings
+++ b/src/Spectre.Console.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
R# and Rider have quite a bit of noise related to documentation in the testing projects, so this disables those warnings.

In the main projects, R# and Rider complain loudly about the namespaces not matching the file structure. The `DotSettings` file disables that warning for any one using those IDEs. Wish this were an editorconfig property, but alas.

Once you get rid of that noise the R# error window starts presenting quite a few opportunities. A lot are redundant code with the nullable support enabled, plus there are some bugs related to multiple enumerations worth looking into, I think.