### PR TITLE
using loop instead of linq to reduce allocs

### DIFF
--- a/src/Spectre.Console/Internal/Cell.cs
+++ b/src/Spectre.Console/Internal/Cell.cs
@@ -8,7 +8,13 @@ namespace Spectre.Console
     {
         public static int GetCellLength(RenderContext context, string text)
         {
-            return text.Sum(rune => GetCellLength(context, rune));
+            var sum = 0;
+            foreach (var rune in text)
+            {
+                sum += GetCellLength(context, rune);
+            }
+
+            return sum;
         }
 
         public static int GetCellLength(RenderContext context, char rune)

--- a/src/Spectre.Console/Rendering/Segment.cs
+++ b/src/Spectre.Console/Rendering/Segment.cs
@@ -135,7 +135,13 @@ namespace Spectre.Console.Rendering
                 throw new ArgumentNullException(nameof(segments));
             }
 
-            return segments.Sum(segment => segment.CellCount(context));
+            var sum = 0;
+            foreach (var segment in segments)
+            {
+                sum += segment.CellCount(context);
+            }
+
+            return sum;
         }
 
         /// <summary>


### PR DESCRIPTION
In both loops, the context is captured preventing caching of the lambda. this results in a pretty significant number of allocations especially with progress bars that constantly are remeasuring

I noticed this while working on the update panel. over a 2-minute-long progress I was seeing a half gig worth of allocations there. After measuring it I noticed a huge portion of the allocations come from these two `Sum` functions. To keep it simple for this I just measured the allocs for the progress example

## before
![before](https://user-images.githubusercontent.com/2447331/109376281-7b59b600-7891-11eb-9f93-39cc1c24bb93.PNG)

## after
![after](https://user-images.githubusercontent.com/2447331/109376282-7dbc1000-7891-11eb-8a98-8c022ae533dd.PNG)

if you check the right-hand side you can see 9mb worth of allocations are gone for even just a 6s run.  For the 2-minute-long version run of the update panel it cut about 320mb out of 500mb.