### PR TITLE
Progress remaining time to show elapsed when finished

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/Columns/HybridTimeColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/HybridTimeColumn.cs
@@ -1,0 +1,62 @@
+using System;
+using Spectre.Console.Rendering;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// A column showing the remaining time of a task, and elapsed time upon completion.
+    /// </summary>
+    public sealed class HybridTimeColumn : ProgressColumn
+    {
+        /// <inheritdoc/>
+        protected internal override bool NoWrap => true;
+
+        /// <summary>
+        /// Gets or sets the style of the remaining time text.
+        /// </summary>
+        public Style Style { get; set; } = new Style(foreground: Color.Blue);
+
+        /// <summary>
+        /// Gets or sets the text style to render the elapsed time on completion.
+        /// </summary>
+        public Style FinishedStyle { get; set; } = new Style(foreground: Color.Green);
+
+        /// <inheritdoc/>
+        public override IRenderable Render(RenderContext context, ProgressTask task, TimeSpan deltaTime)
+        {
+            if (task.IsFinished)
+            {
+                var elapsedTime = task.ElapsedTime;
+                if (elapsedTime == null)
+                {
+                    return new Markup("--:--:--");
+                }
+                else
+                {
+                    return new Text($"{elapsedTime.Value:hh\\:mm\\:ss}", FinishedStyle ?? Style.Plain);
+                }
+            }
+            else
+            {
+                var remaining = task.RemainingTime;
+                if (remaining == null)
+                {
+                    return new Markup("--:--:--");
+                }
+
+                if (remaining.Value.TotalHours > 99)
+                {
+                    return new Markup("**:**:**");
+                }
+
+                return new Text($"{remaining.Value:hh\\:mm\\:ss}", Style ?? Style.Plain);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override int? GetColumnWidth(RenderContext context)
+        {
+            return 8;
+        }
+    }
+}

--- a/src/Spectre.Console/Widgets/Progress/Columns/RemainingTimeColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/RemainingTimeColumn.cs
@@ -8,25 +8,6 @@ namespace Spectre.Console
     /// </summary>
     public sealed class RemainingTimeColumn : ProgressColumn
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RemainingTimeColumn"/> class.
-        /// </summary>
-        public RemainingTimeColumn()
-            : this(false)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RemainingTimeColumn"/> class.
-        /// </summary>
-        /// <param name="elapsedWhenFinished">Indicates if the elapsed time should display when the task is complete.</param>
-        public RemainingTimeColumn(bool elapsedWhenFinished)
-        {
-            _elapsedWhenFinished = elapsedWhenFinished;
-        }
-
-        private readonly bool _elapsedWhenFinished;
-
         /// <inheritdoc/>
         protected internal override bool NoWrap => true;
 
@@ -35,41 +16,21 @@ namespace Spectre.Console
         /// </summary>
         public Style Style { get; set; } = new Style(foreground: Color.Blue);
 
-        /// <summary>
-        /// Gets or sets the text style to render the elapsed time on completion.
-        /// </summary>
-        public Style FinishedStyle { get; set; } = new Style(foreground: Color.Green);
-
         /// <inheritdoc/>
         public override IRenderable Render(RenderContext context, ProgressTask task, TimeSpan deltaTime)
         {
-            if (_elapsedWhenFinished && task.IsFinished)
+            var remaining = task.RemainingTime;
+            if (remaining == null)
             {
-                var elapsedTime = task.ElapsedTime;
-                if (elapsedTime == null)
-                {
-                    return new Markup("--:--:--");
-                }
-                else
-                {
-                    return new Text($"{elapsedTime.Value:hh\\:mm\\:ss}", FinishedStyle ?? Style.Plain);
-                }
+                return new Markup("--:--:--");
             }
-            else
+
+            if (remaining.Value.TotalHours > 99)
             {
-                var remaining = task.RemainingTime;
-                if (remaining == null)
-                {
-                    return new Markup("--:--:--");
-                }
-
-                if (remaining.Value.TotalHours > 99)
-                {
-                    return new Markup("**:**:**");
-                }
-
-                return new Text($"{remaining.Value:hh\\:mm\\:ss}", Style ?? Style.Plain);
+                return new Markup("**:**:**");
             }
+
+            return new Text($"{remaining.Value:hh\\:mm\\:ss}", Style ?? Style.Plain);
         }
 
         /// <inheritdoc/>

--- a/src/Spectre.Console/Widgets/Progress/Columns/RemainingTimeColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/RemainingTimeColumn.cs
@@ -8,6 +8,18 @@ namespace Spectre.Console
     /// </summary>
     public sealed class RemainingTimeColumn : ProgressColumn
     {
+        public RemainingTimeColumn()
+            : this(false)
+        {
+        }
+
+        public RemainingTimeColumn(bool elapsedWhenFinished)
+        {
+            _elapsedWhenFinished = elapsedWhenFinished;
+        }
+
+        private readonly bool _elapsedWhenFinished;
+
         /// <inheritdoc/>
         protected internal override bool NoWrap => true;
 
@@ -16,21 +28,33 @@ namespace Spectre.Console
         /// </summary>
         public Style Style { get; set; } = new Style(foreground: Color.Blue);
 
+        /// <summary>
+        /// Gets or sets the style of the remaining time text.
+        /// </summary>
+        public Style FinishedStyle { get; set; } = new Style(foreground: Color.Green);
+
         /// <inheritdoc/>
         public override IRenderable Render(RenderContext context, ProgressTask task, TimeSpan deltaTime)
         {
-            var remaining = task.RemainingTime;
-            if (remaining == null)
+            if (_elapsedWhenFinished && task.IsFinished)
             {
-                return new Markup("--:--:--");
+                return new Text($"{task.ElapsedTime:hh\\:mm\\:ss}", FinishedStyle ?? Style.Plain);
             }
-
-            if (remaining.Value.TotalHours > 99)
+            else
             {
-                return new Markup("**:**:**");
-            }
+                var remaining = task.RemainingTime;
+                if (remaining == null)
+                {
+                    return new Markup("--:--:--");
+                }
 
-            return new Text($"{remaining.Value:hh\\:mm\\:ss}", Style ?? Style.Plain);
+                if (remaining.Value.TotalHours > 99)
+                {
+                    return new Markup("**:**:**");
+                }
+
+                return new Text($"{remaining.Value:hh\\:mm\\:ss}", Style ?? Style.Plain);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Spectre.Console/Widgets/Progress/Columns/RemainingTimeColumn.cs
+++ b/src/Spectre.Console/Widgets/Progress/Columns/RemainingTimeColumn.cs
@@ -8,11 +8,18 @@ namespace Spectre.Console
     /// </summary>
     public sealed class RemainingTimeColumn : ProgressColumn
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemainingTimeColumn"/> class.
+        /// </summary>
         public RemainingTimeColumn()
             : this(false)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RemainingTimeColumn"/> class.
+        /// </summary>
+        /// <param name="elapsedWhenFinished">Indicates if the elapsed time should display when the task is complete.</param>
         public RemainingTimeColumn(bool elapsedWhenFinished)
         {
             _elapsedWhenFinished = elapsedWhenFinished;
@@ -29,7 +36,7 @@ namespace Spectre.Console
         public Style Style { get; set; } = new Style(foreground: Color.Blue);
 
         /// <summary>
-        /// Gets or sets the style of the remaining time text.
+        /// Gets or sets the text style to render the elapsed time on completion.
         /// </summary>
         public Style FinishedStyle { get; set; } = new Style(foreground: Color.Green);
 
@@ -38,7 +45,15 @@ namespace Spectre.Console
         {
             if (_elapsedWhenFinished && task.IsFinished)
             {
-                return new Text($"{task.ElapsedTime:hh\\:mm\\:ss}", FinishedStyle ?? Style.Plain);
+                var elapsedTime = task.ElapsedTime;
+                if (elapsedTime == null)
+                {
+                    return new Markup("--:--:--");
+                }
+                else
+                {
+                    return new Text($"{elapsedTime.Value:hh\\:mm\\:ss}", FinishedStyle ?? Style.Plain);
+                }
             }
             else
             {


### PR DESCRIPTION
Currently, the progress bar `RemainingTimeColumn` will render as "00:00:00" when the task is finished. It would be nice to have this render the total elapsed time instead once the task is finished. I know I could add the elapsed time column as well, but with both remaining and elapsed displayed it becomes a bit overwhelming visually. This collapses the function of both columns into one.

It is entirely opt-in, and isn't a breaking change. Existing callers will continue to get the same behavior.