### PR TITLE
Adds overloads for MarkUp methods without args

### DIFF
--- a/src/Spectre.Console.Tests/Unit/MarkupTests.cs
+++ b/src/Spectre.Console.Tests/Unit/MarkupTests.cs
@@ -71,5 +71,19 @@ namespace Spectre.Console.Tests.Unit
             // Then
             console.Output.ShouldBe(output);
         }
+
+        [Fact]
+        public void Should_not_fail_with_brackets_on_calls_without_args()
+        {
+            // Given
+            var console = new FakeAnsiConsole(ColorSystem.Standard, AnsiSupport.Yes);
+
+            // When
+            console.MarkupLine("{");
+
+            // Then
+            console.Output.NormalizeLineEndings()
+                .ShouldBe("{\n");
+        }
     }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
@@ -28,7 +28,17 @@ namespace Spectre.Console
         /// <param name="args">An array of objects to write.</param>
         public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
         {
-            console.Render(MarkupParser.Parse(string.Format(provider, format, args)));
+            Markup(console, string.Format(provider, format, args));
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The value to write.</param>
+        public static void Markup(this IAnsiConsole console, string value)
+        {
+            console.Render(MarkupParser.Parse(value));
         }
 
         /// <summary>
@@ -40,6 +50,16 @@ namespace Spectre.Console
         public static void MarkupLine(this IAnsiConsole console, string format, params object[] args)
         {
             MarkupLine(console, CultureInfo.CurrentCulture, format, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The value to write.</param>
+        public static void MarkupLine(this IAnsiConsole console, string value)
+        {
+            Markup(console, value + Environment.NewLine);
         }
 
         /// <summary>


### PR DESCRIPTION
These methods don't require a `string.Format` call so we'll directly call the Render method without a call to `string.Format`. 

Added bonus of a couple fewer allocations too.

Closes #287 