### PR TITLE
Add IProgress<double> to ProgressTask.cs

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
@@ -7,7 +7,7 @@ namespace Spectre.Console
     /// <summary>
     /// Represents a progress task.
     /// </summary>
-    public sealed class ProgressTask
+    public sealed class ProgressTask : IProgress<double>
     {
         private readonly List<ProgressSample> _samples;
         private readonly object _lock;
@@ -290,6 +290,12 @@ namespace Spectre.Console
                 var estimate = (MaxValue - Value) / speed.Value;
                 return TimeSpan.FromSeconds(estimate);
             }
+        }
+
+        /// <inheritdoc />
+        void IProgress<double>.Report(double value)
+        {
+            Update(increment: value - Value);
         }
     }
 }


### PR DESCRIPTION
Makes the Report method an explicit implementation to allow for better interoperability with standard .NET progress functionality while keeping backwards compatibility with existing ProgressTask functionality.

Closes #285