### PR TITLE
Fix Windows ANSI support detection with redirected stderr

### DIFF
--- a/src/Spectre.Console/AnsiConsoleFactory.cs
+++ b/src/Spectre.Console/AnsiConsoleFactory.cs
@@ -68,7 +68,7 @@ namespace Spectre.Console
 
             if (settings.Ansi == AnsiSupport.Detect)
             {
-                (supportsAnsi, legacyConsole) = AnsiDetector.Detect(true);
+                (supportsAnsi, legacyConsole) = AnsiDetector.Detect(buffer.IsStandardError(), true);
 
                 // Check whether or not this is a legacy console from the existing instance (if any).
                 // We need to do this because once we upgrade the console to support ENABLE_VIRTUAL_TERMINAL_PROCESSING
@@ -93,7 +93,7 @@ namespace Spectre.Console
                         else
                         {
                             // Try detecting whether or not this
-                            (_, legacyConsole) = AnsiDetector.Detect(false);
+                            (_, legacyConsole) = AnsiDetector.Detect(buffer.IsStandardError(), false);
                         }
                     }
                 }

--- a/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
+++ b/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
@@ -32,7 +32,7 @@ namespace Spectre.Console
             new Regex("bvterm"), // Bitvise SSH Client
         };
 
-        public static (bool SupportsAnsi, bool LegacyConsole) Detect(bool upgrade)
+        public static (bool SupportsAnsi, bool LegacyConsole) Detect(bool stdError, bool upgrade)
         {
             // Running on Windows?
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -44,7 +44,7 @@ namespace Spectre.Console
                     return (true, false);
                 }
 
-                var supportsAnsi = Windows.SupportsAnsi(upgrade, out var legacyConsole);
+                var supportsAnsi = Windows.SupportsAnsi(stdError, upgrade, out var legacyConsole);
                 return (supportsAnsi, legacyConsole);
             }
 
@@ -72,6 +72,9 @@ namespace Spectre.Console
             private const int STD_OUTPUT_HANDLE = -11;
 
             [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore")]
+            private const int STD_ERROR_HANDLE = -12;
+
+            [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore")]
             private const uint ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
 
             [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore")]
@@ -89,13 +92,13 @@ namespace Spectre.Console
             [DllImport("kernel32.dll")]
             public static extern uint GetLastError();
 
-            public static bool SupportsAnsi(bool upgrade, out bool isLegacy)
+            public static bool SupportsAnsi(bool upgrade, bool stdError, out bool isLegacy)
             {
                 isLegacy = false;
 
                 try
                 {
-                    var @out = GetStdHandle(STD_OUTPUT_HANDLE);
+                    var @out = GetStdHandle(stdError ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE);
                     if (!GetConsoleMode(@out, out var mode))
                     {
                         // Could not get console mode, try TERM (set in cygwin, WSL-Shell).


### PR DESCRIPTION
Currently the Windows ANSI support detection does not take into consideration whether the `AnsiConsole` was created with stdout or stderr as the target.

Assuming:
```csharp
var stderr = AnsiConsole.Create(new AnsiConsoleSettings {Out = Console.Error});
```

If you redirect stderr (e.g. `myapp 2> errors.txt`), `stderr.Profile.Capabilities.Ansi` will still be `true` even though it should be `false`.

Conversely, if you redirect stdout but not stderr (e.g. `myapp > outputs.txt`), `stderr.Profile.Capabilities.Ansi` will still be `false` even though it should be `true`.

I added a new parameter `bool stdError` to `AnsiDetector.Detect` to address this.