### PR TITLE
Adds helper overloads for Markup calls without args

### DIFF
--- a/src/Spectre.Console/AnsiConsole.Markup.cs
+++ b/src/Spectre.Console/AnsiConsole.Markup.cs
@@ -10,6 +10,15 @@ namespace Spectre.Console
         /// <summary>
         /// Writes the specified markup to the console.
         /// </summary>
+        /// <param name="value">The value to write.</param>
+        public static void Markup(string value)
+        {
+            Console.Markup(value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// </summary>
         /// <param name="format">A composite format string.</param>
         /// <param name="args">An array of objects to write.</param>
         public static void Markup(string format, params object[] args)
@@ -26,6 +35,15 @@ namespace Spectre.Console
         public static void Markup(IFormatProvider provider, string format, params object[] args)
         {
             Console.Markup(provider, format, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        public static void MarkupLine(string value)
+        {
+            Console.MarkupLine(value);
         }
 
         /// <summary>


### PR DESCRIPTION
Without specific overloads without the args string.format will get called even if it's not needed. 

This closes #309