### PR TITLE
Fix documentation for ProgressContext.AddTask

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/ProgressContext.cs
+++ b/src/Spectre.Console/Widgets/Progress/ProgressContext.cs
@@ -33,7 +33,7 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="description">The task description.</param>
         /// <param name="settings">The task settings.</param>
-        /// <returns>The task's ID.</returns>
+        /// <returns>The newly created task.</returns>
         public ProgressTask AddTask(string description, ProgressTaskSettings? settings = null)
         {
             lock (_taskLock)


### PR DESCRIPTION
I noticed that the `<returns>` documentation comment for `ProgressContext.AddTask()` is incorrect (possibly just out of date), fixed.

Spectre.Console is really cool, thanks for writing it :)