### PR TITLE
Respect encoding of `TextWriter` provided to `AnsiConsole.Create(...)`

### DIFF
--- a/src/Spectre.Console/AnsiConsoleFactory.cs
+++ b/src/Spectre.Console/AnsiConsoleFactory.cs
@@ -29,7 +29,7 @@ namespace Spectre.Console
             var (supportsAnsi, legacyConsole) = DetectAnsi(settings, buffer);
 
             // Use the provided encoding or fall back to UTF-8
-            var encoding = buffer.IsStandardOut() || buffer.IsStandardError() ? System.Console.OutputEncoding : Encoding.UTF8;
+            var encoding = buffer.IsStandardOut() || buffer.IsStandardError() ? System.Console.OutputEncoding : buffer.Encoding;
 
             // Get the color system
             var colorSystem = settings.ColorSystem == ColorSystemSupport.Detect

--- a/src/Spectre.Console/AnsiConsoleFactory.cs
+++ b/src/Spectre.Console/AnsiConsoleFactory.cs
@@ -28,7 +28,7 @@ namespace Spectre.Console
             // Detect if the terminal support ANSI or not
             var (supportsAnsi, legacyConsole) = DetectAnsi(settings, buffer);
 
-            // Use the provided encoding or fall back to UTF-8
+            // Use console encoding or fall back to provided encoding
             var encoding = buffer.IsStandardOut() || buffer.IsStandardError() ? System.Console.OutputEncoding : buffer.Encoding;
 
             // Get the color system


### PR DESCRIPTION
Currently, encoding defaults to `Encoding.UTF8`, which can lead to issues if the output buffer actually uses a different encoding. 
For example, in my application I'm passing `Console.OpenStandardOutput()` wrapped in a `StreamWriter`, which uses `Console.OutputEncoding`. Because my `StreamWriter` instance doesn't match the `TextWriter` instance in `Console.Out`, the check in `AnsiConsoleFactory` fails and falls back to `Encoding.UTF8` which results in `?` outputted everywhere instead of compatible characters.

This PR changes that behavior and makes it so that the buffer's own encoding is used as fallback instead.

In fact, I'm not entirely sure that checking `buffer.IsStandardOut() || buffer.IsStandardError()` is necessary at this point because `buffer.Encoding` would work in both cases.

Edit: I was able to work around this issue for now with the following hack:

```csharp
  var ansiConsole = AnsiConsole.Create(
      new AnsiConsoleSettings
      {
          Ansi = AnsiSupport.Detect,
          ColorSystem = ColorSystemSupport.Detect,
          Out = output
      }
  );

  // HACK: https://github.com/spectresystems/spectre.console/pull/318
  ansiConsole.Profile.Encoding = output.Encoding;

  return ansiConsole;
```