### PR TITLE
enable disposing ITypeResolver

### DIFF
--- a/examples/Cli/Injection/Infrastructure/TypeResolver.cs
+++ b/examples/Cli/Injection/Infrastructure/TypeResolver.cs
@@ -4,7 +4,7 @@ using Spectre.Console.Cli;
 
 namespace Injection
 {
-    public sealed class TypeResolver : ITypeResolver
+    public sealed class TypeResolver : ITypeResolver, IDisposable
     {
         private readonly IServiceProvider _provider;
 
@@ -16,6 +16,14 @@ namespace Injection
         public object Resolve(Type type)
         {
             return _provider.GetRequiredService(type);
+        }
+
+        public void Dispose()
+        {
+            if (_provider is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
     }
 }

--- a/src/Spectre.Console/Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console/Cli/Internal/CommandExecutor.cs
@@ -76,7 +76,7 @@ namespace Spectre.Console.Cli
             _registrar.RegisterInstance(typeof(IRemainingArguments), parsedResult.Remaining);
 
             // Create the resolver and the context.
-            var resolver = new TypeResolverAdapter(_registrar.Build());
+            using var resolver = new TypeResolverAdapter(_registrar.Build());
             var context = new CommandContext(parsedResult.Remaining, leaf.Command.Name, leaf.Command.Data);
 
             // Execute the command tree.

--- a/src/Spectre.Console/Cli/Internal/TypeResolverAdapter.cs
+++ b/src/Spectre.Console/Cli/Internal/TypeResolverAdapter.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Spectre.Console.Cli
 {
-    internal sealed class TypeResolverAdapter : ITypeResolver
+    internal sealed class TypeResolverAdapter : ITypeResolver, IDisposable
     {
         private readonly ITypeResolver? _resolver;
 
@@ -41,6 +41,14 @@ namespace Spectre.Console.Cli
             catch (Exception ex)
             {
                 throw CommandRuntimeException.CouldNotResolveType(type, ex);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_resolver is IDisposable disposable)
+            {
+                disposable.Dispose();
             }
         }
     }


### PR DESCRIPTION
This PR enables disposing of `TTypeResolver`s when using Spectre's CLI.

In my app I'm using Microsoft.Extensions.DependencyInjection. Though `IServiceProvider` is not disposable, the concrete `ServiceProvider` implements `IDisposable`.

Maybe this use case is too narrow to reason this PR; however, I'm somewhat keen to dispose my resources :wink: