### PR TITLE
Uses Environment.TickCount for seed instead of DateTime.Now

### DIFF
--- a/src/Spectre.Console/Internal/Backends/Ansi/AnsiLinkHasher.cs
+++ b/src/Spectre.Console/Internal/Backends/Ansi/AnsiLinkHasher.cs
@@ -9,7 +9,7 @@ namespace Spectre.Console
 
         public AnsiLinkHasher()
         {
-            _random = new Random(DateTime.Now.Millisecond);
+            _random = new Random(Environment.TickCount);
         }
 
         public int GenerateId(string link, string text)


### PR DESCRIPTION
Every millisecond adds up when we are talking startup time!

![image](https://user-images.githubusercontent.com/2447331/113433822-e70dd200-93ad-11eb-9798-2bf2c5e15392.png)
