### PR TITLE
Replaces emoji regex with ReadOnlySpan implementation

### DIFF
--- a/src/Spectre.Console.Tests/Unit/EmojiTests.cs
+++ b/src/Spectre.Console.Tests/Unit/EmojiTests.cs
@@ -41,5 +41,56 @@ namespace Spectre.Console.Tests.Unit
                 result.ShouldBe("Hello 🌍!");
             }
         }
+
+        public sealed class Parsing
+        {
+            [Theory]
+            [InlineData(":", ":")]
+            [InlineData("::", "::")]
+            [InlineData(":::", ":::")]
+            [InlineData("::::", "::::")]
+            [InlineData("::i:", "::i:")]
+            [InlineData(":i:i:", ":i:i:")]
+            [InlineData("::globe_showing_europe_africa::", ":🌍:")]
+            [InlineData(":globe_showing_europe_africa::globe_showing_europe_africa:", "🌍🌍")]
+            [InlineData("::globe_showing_europe_africa:::test:::globe_showing_europe_africa:::", ":🌍::test::🌍::")]
+            public void Can_Handle_Different_Combinations(string markup, string expected)
+            {
+                // Given
+                var console = new FakeAnsiConsole(ColorSystem.Standard, AnsiSupport.Yes);
+
+                // When
+                console.Markup(markup);
+
+                // Then
+                console.Output.ShouldBe(expected);
+            }
+
+            [Fact]
+            public void Should_Leave_Single_Colons()
+            {
+                // Given
+                var console = new FakeAnsiConsole(ColorSystem.Standard, AnsiSupport.Yes);
+
+                // When
+                console.Markup("Hello :globe_showing_europe_africa:! Output: good");
+
+                // Then
+                console.Output.ShouldBe("Hello 🌍! Output: good");
+            }
+
+            [Fact]
+            public void Unknown_emojis_should_remain()
+            {
+                // Given
+                var console = new FakeAnsiConsole(ColorSystem.Standard, AnsiSupport.Yes);
+
+                // When
+                console.Markup("Hello :globe_showing_flat_earth:!");
+
+                // Then
+                console.Output.ShouldBe("Hello :globe_showing_flat_earth:!");
+            }
+        }
     }
 }

--- a/src/Spectre.Console/Extensions/StringBuilderExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Text;
 
@@ -24,6 +25,17 @@ namespace Spectre.Console
             }
 
             return builder.Append(value);
+        }
+
+        public static void AppendSpan(this StringBuilder builder, ReadOnlySpan<char> span)
+        {
+            // NetStandard 2 lacks the override for StringBuilder to add the span. We'll need to convert the span
+            // to a string for it, but for .NET 5.0 we'll use the override.
+#if NETSTANDARD2_0
+            builder.Append(span.ToString());
+#else
+            builder.Append(span);
+#endif
         }
     }
 }

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Wcwidth" Version="0.2.0" />
+    <PackageReference Include="System.Memory" Version="4.5.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The RegEx runtime perf was never anything noticeable - it was the startup time that was eating over a third of time during initialization. 
 This shaves 200ms off the startup time.

![image](https://user-images.githubusercontent.com/2447331/113464863-e2710a00-93fd-11eb-971a-56fe6eeddbb0.png)

I tried to add as many tests of combinations as possible and the sample apps and things seem to be working just as originally, but if you could hammer on it and try to break it. 

Double check my `ifdef` for netstandard too. It's a little ugly, but should keep netstandard 2.0 support chugging along.