### PR TITLE
Fix OS version detection

### DIFF
--- a/src/Spectre.Console/Internal/Colors/ColorSystemDetector.cs
+++ b/src/Spectre.Console/Internal/Colors/ColorSystemDetector.cs
@@ -25,7 +25,7 @@ namespace Spectre.Console
 
                 var os = Environment.OSVersion;
                 var major = os.Version.Major;
-                var build = os.Version.Minor;
+                var build = os.Version.Build;
 
                 if (major > 10)
                 {


### PR DESCRIPTION
Hello! 👋

This is a quick patch to fix color detection. From the comparison `build >= 15063`, I assume this was meant to use the `Build` part of the OS version, and not the `Minor` part (since Windows 10 versions have the format 10.0.XXXXX). 