### PR TITLE
Marks nullable bools as flags too

### DIFF
--- a/src/Spectre.Console/Cli/Internal/Modelling/CommandModelBuilder.cs
+++ b/src/Spectre.Console/Cli/Internal/Modelling/CommandModelBuilder.cs
@@ -233,7 +233,7 @@ namespace Spectre.Console.Cli
 
         private static ParameterKind GetParameterKind(Type type)
         {
-            if (type == typeof(bool))
+            if (type == typeof(bool) || type == typeof(bool?))
             {
                 return ParameterKind.Flag;
             }


### PR DESCRIPTION
I was trying to create an optional argument, but whenever I marked the bool as nullable Spectre was expecting a value afterwards. 

```csharp
[CommandOption("-d|--detailed")]
public bool? Detailed { get; set; };
```